### PR TITLE
Don't remove prefixed "/" on absolute paths

### DIFF
--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -621,10 +621,12 @@ public class Context
                     }
                     // Remove relative ./ directory.
                     if(startsWith(file, currentDirS))
+                    {    
                         file = file.substring(currentDirS.length());
-                    // Remove possible separator    
-                    if(startsWith(file, java.io.File.separator))
-                        file = file.substring(1);
+                        // Remove possible separator    
+                        if(startsWith(file, java.io.File.separator))
+                            file = file.substring(1);
+                    }
 
 
                     //if it is a idl file.


### PR DESCRIPTION
When using the generator from a path that is not a parent of the file name, the absolute path prefix "/" gets removed on Linux in processPreprocessorLine for scoped files. In custom code, it now assumes a relative path instead of a full path and thus I cannot find the file.