### PR TITLE
Refs #6488 Fix deadlock while waiting for command. [6491]

### DIFF
--- a/src/it/java/com/eprosima/integration/Command.java
+++ b/src/it/java/com/eprosima/integration/Command.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 
 public class Command
 {
@@ -22,15 +23,23 @@ public class Command
             processBuilder.redirectErrorStream(true);
 
             Process process = processBuilder.start();
-            process.waitFor();
 
-            boolean status = process.exitValue() == 0;
-
-            if(!status || !errorOutputOnly)
+            ArrayList<String> output = new ArrayList<String>();
             {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
                 String line = "";
                 while ((line = reader.readLine()) != null)
+                {
+                    output.add(line);
+                }
+            }
+            process.waitFor();
+
+            boolean status = process.exitValue() == 0;
+
+            if (!status || !errorOutputOnly)
+            {
+                for (String line : output)
                 {
                     System.out.println(line);
                 }


### PR DESCRIPTION
This PR fixes a deadlock caused by not consuming output from the executed command, discovered at https://github.com/eProsima/Fast-RTPS-Gen/issues/4#issuecomment-536613903

More details about the issue:
https://stackoverflow.com/questions/5483830/process-waitfor-never-returns