### PR TITLE
parser: add 'getROS2Scopedname' method to return a type name compatible with ROS2

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -56,6 +56,14 @@ public class TreeNode implements Notebook
         return m_scope + "::" + m_name;
     }
 
+    public String getROS2Scopedname()
+    {
+        if(m_scope == null || m_scope.isEmpty())
+            return m_name;
+
+        return m_scope + "::dds_::" + m_name + "_";
+    }
+
     public String getCScopedname()
     {
         if(m_scope.isEmpty())

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -79,6 +79,14 @@ public class AliasTypeCode extends ContainerTypeCode
         return m_scope + "::" + m_name;
     }
 
+    public String getROS2Scopedname()
+    {
+        if(m_scope.isEmpty())
+            return m_name;
+
+        return m_scope + "::dds_::" + m_name + "_";
+    }
+
     public String getScope()
     {
         return m_scope;

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -41,6 +41,14 @@ public abstract class MemberedTypeCode extends TypeCode
         return m_scope + "::" + m_name;
     }
 
+    public String getROS2Scopedname()
+    {
+        if(m_scope.isEmpty())
+            return m_name;
+
+        return m_scope + "::dds_::" + m_name + "_";
+    }
+
     public String getCScopedname()
     {
         if(m_scope.isEmpty())


### PR DESCRIPTION
Composes the fix of https://github.com/eProsima/Fast-RTPS-Gen/issues/19.

In this case, it allows to generate a scope that is compatible with the ROS2 naming.

@LuisGP @richiware for your review and acceptance.