### PR TITLE
Mark unions as not plain

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -238,6 +238,12 @@ public class UnionTypeCode extends MemberedTypeCode
         return Integer.toString(getMaxSerializedSizeWithoutAlignment(0));
     }*/
 
+    @Override
+    public boolean isIsPlain()
+    {
+        return false;
+    }
+
     private TypeCode m_discriminatorTypeCode = null;
 
     private int m_defaultindex = -1;


### PR DESCRIPTION
Just what the title says. Unions should not be marked as plain, as their CDR serialization may not be equal to their in-memory representation.