### PR TITLE
[13986] Add convenience method getCppTypenameForTypeId

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -167,6 +167,12 @@ public abstract class TypeCode implements Notebook
     public boolean isIsUnionType() {return m_kind == Kind.KIND_UNION; }
 
     // Functions to ease TypeIdentifier and TypeObject generation.
+    public String getCppTypenameForTypeId()
+    {
+        String s = getCppTypename();
+        return s.equals("long double") ? "longdouble" : s;
+    }
+    
     public String getTypeIdentifier() { return "TK_None"; }
     public boolean isPrimitiveType() { return false; }
     public boolean isPlainType() { return false; }


### PR DESCRIPTION
Fast DDS Gen is generating wrong TypeObject registration code for types containing arrays or sequences of `long double`.

This PR helps reducing boilerplate code for converting `long double` into `longdouble`, as required by `get_xxx_identifier` calls