### PR TITLE
Fix grammar path in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
                 <artifactId>antlr4-maven-plugin</artifactId>
                 <version>4.5</version>
                 <configuration>
-                    <sourceDirectory>src/main/antlr4/omg</sourceDirectory>
+                    <sourceDirectory>src/main/antlr</sourceDirectory>
                     <arguments>
                         <argument>-package</argument>
                         <argument>com.eprosima.idl.parser.grammar</argument>


### PR DESCRIPTION
This PR updates the path in `pom.xml` to reflect the new location of the `IDL.g4` grammar file.
