### PR TITLE
[15294] Fix isIsBounded for sequences

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -132,28 +132,19 @@ public class SequenceTypeCode extends ContainerTypeCode
     public boolean isIsBounded()
     {
         boolean ret_value = false;
-        boolean should_set_and_unset = getContentTypeCode().isForwarded() && !detect_recursive_;
 
-        if (should_set_and_unset)
+        if (m_maxsize != null)
         {
-            detect_recursive_ = true;
-
-            if (m_maxsize == null)
+            boolean should_set_and_unset = getContentTypeCode().isForwarded() && !detect_recursive_;
+            if (should_set_and_unset)
             {
-                ret_value =  false;
+                detect_recursive_ = true;
+                ret_value =  super.isIsBounded();
+                detect_recursive_ = false;
             }
             else
             {
                 ret_value =  super.isIsBounded();
-            }
-
-            detect_recursive_ = false;
-        }
-        else
-        {
-            if (m_maxsize == null)
-            {
-                ret_value =  false;
             }
         }
 


### PR DESCRIPTION
#57 introduced a regression by which bounded sequences where considered unbounded. This is specially problematic when leveraging Fast DDS Data Sharing delivery mechanism as, because of #57, bounded sequences could not be used. This PR fixes that regression so that bounded sequences are indeed considered bounded