### PR TITLE
[17352] Added post-creation filter for out of bounds positions

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.ParseException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -247,11 +248,11 @@ public class BitmaskTypeCode extends MemberedTypeCode
             // Sanity check
             Set<String> keys = m_bitmasks.keySet();
             for (String key : keys) {
-                if (m_bitmasks.get(key).getPosition() < 0 || m_bitmasks.get(key).getPosition() >= m_bit_bound)
+                int position = m_bitmasks.get(key).getPosition(); 
+                if (position < 0 || position >= m_bit_bound)
                 {
-                    m_value_bitmasks.remove(m_bitmasks.get(key).getPosition());
-                    Member member = (Member)m_bitmasks.remove(key);
-                    removeMember(member);                    
+                    throw new ParseException(null, "Bitmask member "+ key +" out of bounds. Requested position: "
+                    + position + " with @bit_bound value: " + m_bit_bound);
                 }
             }
         }

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
@@ -15,8 +15,10 @@
 package com.eprosima.idl.parser.typecode;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.context.Context;
@@ -156,11 +158,6 @@ public class BitmaskTypeCode extends MemberedTypeCode
             Bitmask bitmask,
             int position)
     {
-        if (position < 0 || position >= m_bit_bound)
-        {
-            return false;                                          // Out of bounds
-
-        }
         if (m_value_bitmasks.containsKey(position))
         {
             return false;                                         // Position already taken
@@ -247,6 +244,16 @@ public class BitmaskTypeCode extends MemberedTypeCode
         if (annotation.getName().equals("bit_bound"))
         {
             m_bit_bound = Integer.parseInt(annotation.getValue());
+            // Sanity check
+            Set<String> keys = m_bitmasks.keySet();
+            for (String key : keys) {
+                if (m_bitmasks.get(key).getPosition() < 0 || m_bitmasks.get(key).getPosition() >= m_bit_bound)
+                {
+                    m_value_bitmasks.remove(m_bitmasks.get(key).getPosition());
+                    Member member = (Member)m_bitmasks.remove(key);
+                    removeMember(member);                    
+                }
+            }
         }
     }
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
@@ -16,7 +16,6 @@ package com.eprosima.idl.parser.typecode;
 
 import com.eprosima.idl.parser.exception.ParseException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -98,6 +98,17 @@ public abstract class MemberedTypeCode extends TypeCode
         return false;
     }
 
+    public boolean removeMember(Member member)
+    {
+        if(m_members.containsKey(member.getName()))
+        {
+            m_members.remove(member.getName());
+            return true;
+        }
+        return false;
+    }
+
+
     @Override
     public abstract String getCppTypename();
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -98,17 +98,6 @@ public abstract class MemberedTypeCode extends TypeCode
         return false;
     }
 
-    public boolean removeMember(Member member)
-    {
-        if(m_members.containsKey(member.getName()))
-        {
-            m_members.remove(member.getName());
-            return true;
-        }
-        return false;
-    }
-
-
     @Override
     public abstract String getCppTypename();
 


### PR DESCRIPTION
Currently, the `@bit_bound` seems to be applied after the `@position` calculation for members of a bitmask. This PR introduces a filter that removes all out-of-bounds members after the bit_bound update. 