### PR TITLE
Add int8 and uint8t to CTypes template

### DIFF
--- a/src/main/resources/com/eprosima/idl/templates/CTypes.stg
+++ b/src/main/resources/com/eprosima/idl/templates/CTypes.stg
@@ -42,6 +42,10 @@ type_9() ::= <<uint8_t>>
 
 type_d(maxsize) ::= <<char>>
 
+type_1d(name) ::= <<int8_t>>
+
+type_1e(name) ::= <<uint8_t>>
+
 //TODO
 type_15() ::= <<wchar>>
 


### PR DESCRIPTION
Fix for https://github.com/eProsima/Micro-XRCE-DDS-Gen/issues/54

Tiny integer types were missing on CTypes template.