### PR TITLE
Add isIsEnumType() for use in StringTemplate

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
@@ -39,6 +39,12 @@ public class EnumTypeCode extends MemberedTypeCode
     }
 
     @Override
+    public boolean isIsEnumType()
+    {
+        return true;
+    }
+
+    @Override
     public String getTypeIdentifier()
     {
         return "EK_MINIMAL";

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -224,6 +224,11 @@ public abstract class TypeCode implements Notebook
         return false;
     }
 
+    public boolean isIsEnumType()
+    {
+        return false;
+    }
+
     public boolean isIsSetType()
     {
         return false;


### PR DESCRIPTION
Add IsEnumType() to distinguish between enums and other primitive types.