### PR TITLE
Fix returning is_plain [19541]

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/exception/RuntimeGenerationException.java
+++ b/src/main/java/com/eprosima/idl/parser/exception/RuntimeGenerationException.java
@@ -1,4 +1,4 @@
-// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,21 +14,18 @@
 
 package com.eprosima.idl.parser.exception;
 
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Token;
+import java.lang.Exception;
+import com.eprosima.log.ColorMessage;
 
-public class ParseException extends RecognitionException
+public class RuntimeGenerationException extends Exception
 {
-    public ParseException()
+    public RuntimeGenerationException()
     {
-        super("", null, null, null);
+        super("");
     }
 
-    public ParseException(Token token, String message)
+    public RuntimeGenerationException(String message)
     {
-        super(message, null, null, null);
-
-        if(token != null)
-            setOffendingToken(token);
+        super(ColorMessage.error() + message);
     }
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -116,14 +116,20 @@ public abstract class MemberedTypeCode extends TypeCode
     @Override
     public boolean isIsPlain()
     {
-        for (Member member : m_members.values())
+        if (isAnnotationFinal())
         {
-            if (!member.isIsPlain())
+            for (Member member : m_members.values())
             {
-                return false;
+                if (!member.isIsPlain())
+                {
+                    return false;
+                }
             }
+
+            return true;
         }
-        return true;
+
+        return false;
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -48,6 +48,7 @@ public abstract class TypeCode implements Notebook
         }
     };
 
+    public static ExtensibilityKind default_extensibility = ExtensibilityKind.APPENDABLE;
     public static STGroup idltypesgr  = null;
     public static STGroup cpptypesgr  = null;
     public static STGroup ctypesgr    = null;
@@ -369,6 +370,12 @@ public abstract class TypeCode implements Notebook
             {
                 extensibility_ = ExtensibilityKind.FINAL;
             }
+            else if (null != m_annotations.get(Annotation.appendable_str) ||
+                    (null != m_annotations.get(Annotation.extensibility_str) &&
+                     m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_appendable_str)))
+            {
+                extensibility_ = ExtensibilityKind.APPENDABLE;
+            }
             else if (null != m_annotations.get(Annotation.mutable_str) ||
                     (null != m_annotations.get(Annotation.extensibility_str) &&
                      m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_mutable_str)))
@@ -377,7 +384,7 @@ public abstract class TypeCode implements Notebook
             }
             else
             {
-                extensibility_ = ExtensibilityKind.APPENDABLE;
+                extensibility_ = default_extensibility;
             }
         }
     }


### PR DESCRIPTION
Only a MemberedTypeCode is plain if the extensibility is final.
Also added exception RuntimeGenerationException.
Also added TypeCode.default_extensibility