### PR TITLE
[19668] Fixed bug when using const as literals.

### DIFF
--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -1886,7 +1886,7 @@ sequence_type returns [SequenceTypeCode typecode = null]
     Definition def = null;
 }
     :   ( (KW_SEQUENCE)
-        LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } COMA positive_int_const { maxsize=ctx.evaluate_literal($positive_int_const.literalStr); } RIGHT_ANG_BRACKET
+        LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } COMA positive_int_const { maxsize=$positive_int_const.literalStr; } RIGHT_ANG_BRACKET
     |   (KW_SEQUENCE)
         LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } RIGHT_ANG_BRACKET )
         {
@@ -1909,7 +1909,7 @@ set_type returns [SetTypeCode typecode = null]
     String maxsize = null;
     Definition def = null;
 } : ( KW_SET
-        LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } COMA positive_int_const { maxsize=ctx.evaluate_literal($positive_int_const.literalStr); } RIGHT_ANG_BRACKET
+        LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } COMA positive_int_const { maxsize=$positive_int_const.literalStr; } RIGHT_ANG_BRACKET
     |   KW_SET
         LEFT_ANG_BRACKET simple_type_spec[null] { type=$simple_type_spec.typecode; def=$simple_type_spec.def; } RIGHT_ANG_BRACKET )
         {
@@ -1943,7 +1943,7 @@ map_type returns [MapTypeCode typecode = null]
             valueType=$simple_type_spec.typecode;
             valueDef=$simple_type_spec.def;
         }
-        (COMA positive_int_const { maxsize=ctx.evaluate_literal($positive_int_const.literalStr); } )?
+        (COMA positive_int_const { maxsize=$positive_int_const.literalStr; } )?
         RIGHT_ANG_BRACKET
         {
             $typecode = ctx.createMapTypeCode(maxsize);
@@ -1972,7 +1972,7 @@ string_type returns [TypeCode typecode = null]
 @init{
     String maxsize = null;
 }
-    :   ( KW_STRING LEFT_ANG_BRACKET positive_int_const { maxsize=ctx.evaluate_literal($positive_int_const.literalStr); } RIGHT_ANG_BRACKET
+    :   ( KW_STRING LEFT_ANG_BRACKET positive_int_const { maxsize=$positive_int_const.literalStr; } RIGHT_ANG_BRACKET
     |   KW_STRING )
        {$typecode = ctx.createStringTypeCode(Kind.KIND_STRING, maxsize);}
     ;
@@ -1982,7 +1982,7 @@ wide_string_type returns [TypeCode typecode = null]
 {
     String maxsize = null;
 }
-    :   ( KW_WSTRING LEFT_ANG_BRACKET positive_int_const { maxsize=ctx.evaluate_literal($positive_int_const.literalStr); } RIGHT_ANG_BRACKET
+    :   ( KW_WSTRING LEFT_ANG_BRACKET positive_int_const { maxsize=$positive_int_const.literalStr; } RIGHT_ANG_BRACKET
     |   KW_WSTRING )
        {$typecode = ctx.createStringTypeCode(Kind.KIND_WSTRING, maxsize);}
     ;
@@ -1997,7 +1997,7 @@ array_declarator returns [Pair<Pair<String, Token>, ContainerTypeCode> pair = nu
         (
             fixed_array_size
             {
-               typecode.addDimension(ctx.evaluate_literal($fixed_array_size.literalStr));
+               typecode.addDimension($fixed_array_size.literalStr, ctx.evaluate_literal($fixed_array_size.literalStr));
             }
         )+
         {

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -592,7 +592,7 @@ public class Context
     public MapTypeCode createMapTypeCode(
             String maxsize)
     {
-        return new MapTypeCode(maxsize);
+        return new MapTypeCode(maxsize, evaluate_literal(maxsize));
     }
 
     public PrimitiveTypeCode createPrimitiveTypeCode(
@@ -604,20 +604,20 @@ public class Context
     public SequenceTypeCode createSequenceTypeCode(
             String maxsize)
     {
-        return new SequenceTypeCode(maxsize);
+        return new SequenceTypeCode(maxsize, evaluate_literal(maxsize));
     }
 
     public SetTypeCode createSetTypeCode(
             String maxsize)
     {
-        return new SetTypeCode(maxsize);
+        return new SetTypeCode(maxsize, evaluate_literal(maxsize));
     }
 
     public StringTypeCode createStringTypeCode(
             int kind,
             String maxsize)
     {
-        return new StringTypeCode(kind, maxsize);
+        return new StringTypeCode(kind, maxsize, evaluate_literal(maxsize));
     }
 
     public StructTypeCode createStructTypeCode(
@@ -1302,6 +1302,11 @@ public class Context
     public String evaluate_literal(
             String str)
     {
+        if (null == str)
+        {
+            return null;
+        }
+
         String aux_str = "(" + str.replace("::", "_") + ") | 0";
         String const_str = "";
 

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -1302,7 +1302,7 @@ public class Context
     public String evaluate_literal(
             String str)
     {
-        String aux_str = "(" + str + ") | 0";
+        String aux_str = "(" + str.replace("::", "_") + ") | 0";
         String const_str = "";
 
         // Add all constants.
@@ -1313,13 +1313,18 @@ public class Context
             {
                 ConstDeclaration const_decl = (ConstDeclaration)definition;
 
-                if (const_decl.getTypeCode().isPrimitive())
+                if (const_decl.getTypeCode().isPrimitive() || const_decl.getTypeCode().isIsStringType() || const_decl.getTypeCode().isIsWStringType())
                 {
-                    const_str = const_str + ";" + const_decl.getName() + "=" + const_decl.getValue();
+                    if(str.contains("::")){
+                        const_str = const_str + ";" + const_decl.getFormatedScopedname() + "=" + const_decl.getValue();
+                    }else{
+                        const_str = const_str + ";" + const_decl.getName() + "=" + const_decl.getValue();
+                    }
                 }
             }
         }
 
+        const_str = const_str.replace("=L'", "='").replace("=L\"", "=\""); // remove "L" from wchar and wstring declarations
         aux_str = const_str + ";" + aux_str;
 
         // Process the math expression

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -1320,9 +1320,10 @@ public class Context
 
                 if (const_decl.getTypeCode().isPrimitive() || const_decl.getTypeCode().isIsStringType() || const_decl.getTypeCode().isIsWStringType())
                 {
-                    if(str.contains("::")){
-                        const_str = const_str + ";" + const_decl.getFormatedScopedname() + "=" + const_decl.getValue();
-                    }else{
+                    const_str = const_str + ";" + const_decl.getFormatedScopedname() + "=" + const_decl.getValue();
+
+                    if (const_decl.getScope() == getScope())
+                    {
                         const_str = const_str + ";" + const_decl.getName() + "=" + const_decl.getValue();
                     }
                 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/ArrayTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/ArrayTypeCode.java
@@ -25,7 +25,6 @@ public class ArrayTypeCode extends ContainerTypeCode
     public ArrayTypeCode()
     {
         super(Kind.KIND_ARRAY);
-        m_dimensions = new ArrayList<String>();
     }
 
     @Override
@@ -169,14 +168,21 @@ public class ArrayTypeCode extends ContainerTypeCode
     }
 
     public void addDimension(
-            String dimension)
+            String dimension,
+            String evaluated_dimension)
     {
         m_dimensions.add(dimension);
+        evaluated_dimensions_.add(evaluated_dimension);
     }
 
     public List<String> getDimensions()
     {
         return m_dimensions;
+    }
+
+    public List<String> getEvaluatedDimensions()
+    {
+        return evaluated_dimensions_;
     }
 
     public String getSize()
@@ -242,5 +248,7 @@ public class ArrayTypeCode extends ContainerTypeCode
         return initial_value;
     }
 
-    private List<String> m_dimensions;
+    private List<String> m_dimensions = new ArrayList<String>();
+
+    private List<String> evaluated_dimensions_ = new ArrayList<String>();
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
@@ -21,10 +21,12 @@ import com.eprosima.idl.parser.tree.Definition;
 public class MapTypeCode extends ContainerTypeCode
 {
     public MapTypeCode(
-            String maxsize)
+            String maxsize,
+            String evaluated_maxsize)
     {
         super(Kind.KIND_MAP);
         m_maxsize = maxsize;
+        evaluated_maxsize_ = evaluated_maxsize;
     }
 
     public boolean isIsType_19()
@@ -100,6 +102,16 @@ public class MapTypeCode extends ContainerTypeCode
         return m_maxsize;
     }
 
+    public String getEvaluatedMaxsize()
+    {
+        if (evaluated_maxsize_ == null)
+        {
+            return getMaxsize();
+        }
+
+        return evaluated_maxsize_;
+    }
+
     public TypeCode getKeyTypeCode()
     {
         return m_keyTypeCode;
@@ -170,4 +182,5 @@ public class MapTypeCode extends ContainerTypeCode
     private Definition m_keyDefinition = null;
     private Definition m_valueDefinition = null;
     private String m_maxsize = null;
+    private String evaluated_maxsize_ = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -22,10 +22,12 @@ import org.stringtemplate.v4.ST;
 public class SequenceTypeCode extends ContainerTypeCode
 {
     public SequenceTypeCode(
-            String maxsize)
+            String maxsize,
+            String evaluated_maxsize)
     {
         super(Kind.KIND_SEQUENCE);
         m_maxsize = maxsize;
+        evaluated_maxsize_ = evaluated_maxsize;
     }
 
     @Override
@@ -117,6 +119,16 @@ public class SequenceTypeCode extends ContainerTypeCode
         return m_maxsize;
     }
 
+    public String getEvaluatedMaxsize()
+    {
+        if (evaluated_maxsize_ == null)
+        {
+            return getMaxsize();
+        }
+
+        return evaluated_maxsize_;
+    }
+
     public boolean isUnbound()
     {
         return null == m_maxsize;
@@ -152,6 +164,8 @@ public class SequenceTypeCode extends ContainerTypeCode
     }
 
     private String m_maxsize = null;
+
+    private String evaluated_maxsize_ = null;
 
     protected boolean detect_recursive_ = false;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/SetTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SetTypeCode.java
@@ -20,10 +20,12 @@ import org.stringtemplate.v4.ST;
 public class SetTypeCode extends ContainerTypeCode
 {
     public SetTypeCode(
-            String maxsize)
+            String maxsize,
+            String evaluate_maxsize)
     {
         super(Kind.KIND_SET);
         m_maxsize = maxsize;
+        evaluated_maxsize_ = evaluate_maxsize;
     }
 
     @Override
@@ -96,6 +98,16 @@ public class SetTypeCode extends ContainerTypeCode
         return m_maxsize;
     }
 
+    public String getEvaluatedMaxsize()
+    {
+        if (evaluated_maxsize_ == null)
+        {
+            return getMaxsize();
+        }
+
+        return evaluated_maxsize_;
+    }
+
     @Override
     public boolean isIsPlain()
     {
@@ -114,4 +126,6 @@ public class SetTypeCode extends ContainerTypeCode
     }
 
     private String m_maxsize = null;
+
+    private String evaluated_maxsize_ = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
@@ -22,10 +22,12 @@ public class StringTypeCode extends TypeCode
 {
     public StringTypeCode(
             int kind,
-            String maxsize)
+            String maxsize,
+            String evaluated_maxsize)
     {
         super(kind);
         m_maxsize = maxsize;
+        evaluated_maxsize_ = evaluated_maxsize;
     }
 
     @Override
@@ -104,6 +106,16 @@ public class StringTypeCode extends TypeCode
         return m_maxsize;
     }
 
+    public String getEvaluatedMaxsize()
+    {
+        if (evaluated_maxsize_ == null)
+        {
+            return getMaxsize();
+        }
+
+        return evaluated_maxsize_;
+    }
+
     @Override
     public boolean isIsPlain()
     {
@@ -117,4 +129,5 @@ public class StringTypeCode extends TypeCode
     }
 
     private String m_maxsize = null;
+    private String evaluated_maxsize_ = null;
 }


### PR DESCRIPTION
Fixed bug when using const as literals.
Reported in https://github.com/eProsima/Fast-DDS-Gen/issues/55
Found aditional problems with wchar and wstring literals.