### PR TITLE
[19897] Bump version to 2.0.0

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,22 @@
+# .github/workflows/mirror.yml
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    name: Mirror master branch to API & ABI compatible minor version branches
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '2.0.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: ${{ matrix.dest_branch }}

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ sourceSets {
 }
 
 group = "com.eprosima"
-version = "1.7.2"
+version = "2.0.0"
 
 //general properties
 jar {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.eprosima.idl</groupId>
     <artifactId>com.eprosima.idl</artifactId>
-    <version>1.7.2</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <build>


### PR DESCRIPTION
This PR:

1. Bumps project version to 2.0.0
2. Adds a mirror workflow so that the latest version branch is kept up to date with master.
This is necessary to transition to a branching model similar to Fast DDS', where master is kept as a development branch, and each minor version has a corresponding X.Y.x branch so we can handle backports and releases in a more consistent manner.
3. Adds a dco.yml so that GPG signed commits automatically pass the DCO