### PR TITLE
Several changes to support fastddsgen -genapi [19957]

### DIFF
--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -176,27 +176,11 @@ module returns [Pair<com.eprosima.idl.parser.tree.Module, TemplateGroup> returnP
         if(moduleObject == null)
         {
             // Create the Module object.
-            moduleObject = new com.eprosima.idl.parser.tree.Module(ctx.getScopeFile(), ctx.isInScopedFile(), ctx.getScope(), name, tk);
-            //ctx.addPendingModule(moduleObject);
+            moduleObject = ctx.createModule(ctx.getScopeFile(), ctx.isInScopedFile(), ctx.getScope(), name, tk);
         }
 
-        // Add the module to the context.
-        ctx.addModule(moduleObject);
-
-        if(ctx.isInScopedFile() || ctx.isScopeLimitToAll()) {
-            if(tmanager != null) {
-                moduleTemplates = tmanager.createTemplateGroup("module");
-                moduleTemplates.setAttribute("ctx", ctx);
-                // Set the module object to the TemplateGroup of the module.
-                moduleTemplates.setAttribute("module", moduleObject);
-            }
-        }
-
-        // Update to a new namespace.
-        if(old_scope.isEmpty())
-            ctx.setScope(name);
-        else
-            ctx.setScope(old_scope + "::" + name);
+        // Add the module to the context and update to the new namespace (internally call ctx.setScope)
+        moduleTemplates = ctx.addModule(moduleObject);
     }
     // Each definition is stored in the Module and each TemplateGroup is set as attribute in the TemplateGroup of the module.
     LEFT_BRACE
@@ -1587,7 +1571,7 @@ member_list [StructTypeCode structTP] returns [TemplateGroup tg = null]
                         if(pair.first().second() != null)
                         {
                             $tg = pair.first().second();
-                        }                        
+                        }
                     }
                 }
             }

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.idl.context;
 
+import com.eprosima.idl.generator.manager.TemplateGroup;
+import com.eprosima.idl.generator.manager.TemplateManager;
 import com.eprosima.idl.parser.exception.ParseException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.AnnotationDeclaration;
@@ -63,6 +65,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import org.antlr.v4.runtime.Token;
+import org.stringtemplate.v4.STGroupFile;
 
 
 
@@ -70,9 +73,15 @@ import org.antlr.v4.runtime.Token;
 public class Context
 {
     public Context(
+            TemplateManager tmanager,
             String file,
-            ArrayList<String> includePaths)
+            ArrayList<String> includePaths,
+            boolean generate_typesc
+            )
     {
+        tmanager_ = tmanager;
+        generate_typesc_ = generate_typesc;
+
         // Detect OS
         m_os = System.getProperty("os.name");
         m_userdir = System.getProperty("user.dir");
@@ -120,7 +129,7 @@ public class Context
         m_scopeFilesStack = new Stack<Pair<String, Integer>>();
         for (int i = 0; i < includePaths.size(); ++i)
         {
-            String include = (String)includePaths.get(i);
+            String include = includePaths.get(i);
             if (startsWith(include, includeFlag))
             {
                 include = include.substring(includeFlag.length());
@@ -171,6 +180,20 @@ public class Context
                 ++pointer;
             }
         }
+
+        // Load IDL types for stringtemplates
+        TypeCode.ctx = this;
+        TypeCode.idltypesgr = new STGroupFile("com/eprosima/idl/templates/idlTypes.stg", '$', '$');
+        if (generate_typesc)
+        {
+            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/TypesCInterface.stg", '$', '$');
+        }
+        else
+        {
+            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/Types.stg", '$', '$');
+        }
+        TypeCode.ctypesgr = new STGroupFile("com/eprosima/idl/templates/CTypes.stg", '$', '$');
+        TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
 
         // Add here builtin annotations? (IDL 4.2 - 8.3.1 section)
         AnnotationDeclaration idann = createAnnotationDeclaration("id", null);
@@ -374,13 +397,29 @@ public class Context
      * @brief This function adds a module to the context.
      * This function is used in the parser.
      */
-    public void addModule(
+    public TemplateGroup addModule(
             com.eprosima.idl.parser.tree.Module module)
     {
+        TemplateGroup moduleTemplates = null;
+
         if (!m_modules.containsKey(module.getScopedname()))
         {
             m_modules.put(module.getScopedname(), module);
         }
+
+        if(isInScopedFile() || isScopeLimitToAll()) {
+            if(tmanager_ != null) {
+                moduleTemplates = tmanager_.createTemplateGroup("module");
+                moduleTemplates.setAttribute("ctx", this);
+                // Set the module object to the TemplateGroup of the module.
+                moduleTemplates.setAttribute("module", module);
+            }
+        }
+
+        // Change context scope.
+        setScope(module.getScopedname());
+
+        return moduleTemplates;
     }
 
     public com.eprosima.idl.parser.tree.Module existsModule(
@@ -528,6 +567,16 @@ public class Context
         }
 
         return returnedValue;
+    }
+
+    public com.eprosima.idl.parser.tree.Module createModule(
+            String scope_file,
+            boolean is_in_scope,
+            String scope,
+            String name,
+            Token token)
+    {
+        return new com.eprosima.idl.parser.tree.Module (scope_file, is_in_scope, scope, name, token);
     }
 
     public Operation createOperation(
@@ -1351,6 +1400,11 @@ public class Context
         return aux_str;
     }
 
+    public boolean isGenerateTypesC()
+    {
+        return generate_typesc_;
+    }
+
     // OS
     String m_os = null;
     String m_userdir = null;
@@ -1401,4 +1455,8 @@ public class Context
     private HashSet<String> m_keywords = null;
 
     private boolean m_ignore_case = true;
+
+    private boolean generate_typesc_ = false;
+
+    protected TemplateManager tmanager_ = null;
 }

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -417,7 +417,14 @@ public class Context
         }
 
         // Change context scope.
-        setScope(module.getScopedname());
+        if (m_scope.isEmpty())
+        {
+            setScope(module.getName());
+        }
+        else
+        {
+            setScope(m_scope + "::" + module.getName());
+        }
 
         return moduleTemplates;
     }
@@ -736,7 +743,7 @@ public class Context
         TypeCode returnedValue = null;
         TypeDeclaration typedecl = m_types.get(name);
 
-        // Probar si no tiene scope, con el scope actual.
+        // Wether the name doesn't contain scope, test with the current scope.
         if (typedecl == null)
         {
             String scope = m_scope;

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
@@ -15,8 +15,6 @@
 package com.eprosima.idl.generator.manager;
 
 import com.eprosima.idl.generator.manager.TemplateGroup;
-import com.eprosima.idl.parser.typecode.TypeCode;
-import com.eprosima.idl.context.Context;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -34,23 +32,6 @@ public class TemplateManager
     private Map<String, STGroup> m_groups = new HashMap<String, STGroup>();
 
     private boolean st_error_ = false;
-
-    public TemplateManager(String stackTemplateNames, Context ctx, boolean generate_typesc)
-    {
-        // Load IDL types for stringtemplates
-        TypeCode.idltypesgr = new STGroupFile("com/eprosima/idl/templates/idlTypes.stg", '$', '$');
-        if (generate_typesc)
-        {
-            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/TypesCInterface.stg", '$', '$');
-        }
-        else
-        {
-            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/Types.stg", '$', '$');
-        }
-        TypeCode.ctypesgr = new STGroupFile("com/eprosima/idl/templates/CTypes.stg", '$', '$');
-        TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
-        TypeCode.ctx = ctx;
-    }
 
     public void addGroup(String groupname)
     {

--- a/src/main/java/com/eprosima/idl/test/TestIDLParser.java
+++ b/src/main/java/com/eprosima/idl/test/TestIDLParser.java
@@ -19,6 +19,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 
 
 import com.eprosima.idl.context.Context;
+import com.eprosima.idl.generator.manager.TemplateManager;
 import com.eprosima.idl.parser.grammar.IDLLexer;
 import com.eprosima.idl.parser.grammar.IDLParser;
 import com.eprosima.idl.parser.tree.Annotation;
@@ -75,7 +76,8 @@ public class TestIDLParser {
             return;
         }
 
-        Context context = new Context(idlFileName, m_includePaths);
+        TemplateManager tmanager = new TemplateManager();
+        Context context = new Context(tmanager, idlFileName, m_includePaths, false);
 
         try {
 


### PR DESCRIPTION
This PR contains:

- `Context` contains a new function `createModule()` which can be override.
- Now `Context` `addModule()` function is the responsible of calling `module` template and setting the current scope.
- Moved the loading of templates related about Types from `TemplateManager` to `Context`.
- Now `Context` constructor expects an instance of `TemplateManager`.