### PR TITLE
Fixed member_id for unions.

### DIFF
--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -27,6 +27,7 @@ grammar IDL;
     import com.eprosima.idl.parser.strategy.DefaultErrorStrategy;
     import com.eprosima.idl.parser.listener.DefaultErrorListener;
     import com.eprosima.idl.parser.exception.ParseException;
+    import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 
     import java.util.Vector;
 }
@@ -1753,7 +1754,15 @@ union_type [Vector<Annotation> annotations, ArrayList<Definition> defs] returns 
             // TODO Check supported types for discriminator: long, enumeration, etc...
             if (fw_decl)
             {
-                unionTP.setDiscriminatorType(dist_type);
+                try
+                {
+                    unionTP.setDiscriminatorType(dist_type);
+                }
+                catch (RuntimeGenerationException ex)
+                {
+                    System.out.println("ERROR ("+ ex.getMessage()+ ")");
+                    throw new ParseException(_input.LT(1), fw_name + " wrong discriminator member_id");
+                }
             }
             else
             {

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -22,8 +22,8 @@ import org.stringtemplate.v4.ST;
 
 import com.eprosima.idl.context.Context;
 import com.eprosima.idl.parser.exception.ParseException;
-import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.tree.Annotation;
 
 
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -44,6 +44,7 @@ public class UnionTypeCode extends MemberedTypeCode
         super(Kind.KIND_UNION, scope, name);
         m_discriminatorTypeCode = discriminatorTypeCode;
         ++last_index_;
+        ++last_id_;
     }
 
     public void setDiscriminatorType(
@@ -51,6 +52,7 @@ public class UnionTypeCode extends MemberedTypeCode
     {
         m_discriminatorTypeCode = discriminatorTypeCode;
         ++last_index_;
+        ++last_id_;
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,11 +50,15 @@ public class UnionTypeCode extends MemberedTypeCode
     }
 
     public void setDiscriminatorType(
-            TypeCode discriminatorTypeCode)
+            TypeCode discriminatorTypeCode) throws RuntimeGenerationException
     {
         m_discriminatorTypeCode = discriminatorTypeCode;
         ++last_index_;
         ++last_id_;
+        if(last_id_ != 0)
+        {
+            throw new RuntimeGenerationException("UnionTypeCode::setDiscriminatorType(): Discriminator member_id is not 0.");
+        }
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -14,8 +14,6 @@
 
 package com.eprosima.idl.parser.typecode;
 
-import com.eprosima.idl.parser.exception.RuntimeGenerationException;
-
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +23,7 @@ import org.stringtemplate.v4.ST;
 import com.eprosima.idl.context.Context;
 import com.eprosima.idl.parser.exception.ParseException;
 import com.eprosima.idl.parser.tree.Annotation;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 
 
 


### PR DESCRIPTION
Fix the union member_ids to account for the fact that the discriminator should always have the ID 0.