### PR TITLE
XTypes v1.3 refactor

### DIFF
--- a/src/it/java/com/eprosima/integration/Test.java
+++ b/src/it/java/com/eprosima/integration/Test.java
@@ -49,7 +49,7 @@ public class Test
             boolean testFlag)
     {
         String program = "java -jar " + generatorName + ".jar";
-        String flags = " -replace -example" + " " + exampleArch + (testFlag ? " -test" : "");
+        String flags = " -replace -example" + " " + exampleArch + (testFlag ? " -test -default-container-prealloc-size 50" : "");
         String output = " -d " + outputPath;
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";
@@ -65,7 +65,7 @@ public class Test
             boolean testFlag)
     {
         String program = "java -jar " + generatorName + ".jar";
-        String flags = " -replace -example" + (testFlag ? " -test" : "");
+        String flags = " -replace -example" + (testFlag ? " -test -default-container-prealloc-size 50" : "");
         String output = " -d " + outputPath;
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";

--- a/src/it/java/com/eprosima/integration/Test.java
+++ b/src/it/java/com/eprosima/integration/Test.java
@@ -46,11 +46,10 @@ public class Test
             String generatorName,
             String inputPath,
             String exampleArch,
-            String cdr_version,
             boolean testFlag)
     {
         String program = "java -jar " + generatorName + ".jar";
-        String flags = " -cdr " + cdr_version + " -replace -example" + " " + exampleArch + (testFlag ? " -test" : "");
+        String flags = " -replace -example" + " " + exampleArch + (testFlag ? " -test" : "");
         String output = " -d " + outputPath;
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";
@@ -63,11 +62,10 @@ public class Test
     public boolean generate(
             String generatorName,
             String inputPath,
-            String cdr_version,
             boolean testFlag)
     {
         String program = "java -jar " + generatorName + ".jar";
-        String flags = " -cdr " + cdr_version + " -replace -example" + (testFlag ? " -test" : "");
+        String flags = " -replace -example" + (testFlag ? " -test" : "");
         String output = " -d " + outputPath;
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";

--- a/src/it/java/com/eprosima/integration/Test.java
+++ b/src/it/java/com/eprosima/integration/Test.java
@@ -54,6 +54,11 @@ public class Test
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";
 
+        if (idl.equals("external") || idl.equals("declarations"))
+        {
+            flags = flags + " -no-typeobjectsupport";
+        }
+
         String command = program + flags + output + idlPath;
 
         return Command.execute(command, null, errorOutputOnly, true);
@@ -69,6 +74,11 @@ public class Test
         String output = " -d " + outputPath;
 
         String idlPath = " " + inputPath + "/" + idl + ".idl";
+
+        if (idl.equals("external") || idl.equals("declarations"))
+        {
+            flags = flags + " -no-typeobjectsupport";
+        }
 
         String command = program + flags + output + idlPath;
         return Command.execute(command, null, errorOutputOnly, true);

--- a/src/it/java/com/eprosima/integration/TestManager.java
+++ b/src/it/java/com/eprosima/integration/TestManager.java
@@ -39,14 +39,12 @@ public class TestManager
     private String exampleArch;
     private List<String> cMakeArgs;
     private boolean errorOutputOnly;
-    private String cdr_version_;
 
     public TestManager(
             TestLevel level,
             String generatorName,
             String inputPath,
             String outputPath,
-            String cdr_version,
             List<String> list_tests,
             List<String> blacklist_tests)
     {
@@ -59,7 +57,6 @@ public class TestManager
         this.exampleArch = null;
         this.cMakeArgs = new ArrayList<String>();
         this.errorOutputOnly = true;
-        this.cdr_version_ = cdr_version;
     }
 
     public TestManager(
@@ -68,7 +65,6 @@ public class TestManager
             String inputPath,
             String outputPath,
             String exampleArch,
-            String cdr_version,
             List<String> list_tests,
             List<String> blacklist_tests)
     {
@@ -81,7 +77,6 @@ public class TestManager
         this.exampleArch = exampleArch;
         this.cMakeArgs = new ArrayList<String>();
         this.errorOutputOnly = true;
-        this.cdr_version_ = cdr_version;
     }
 
     public void processIDLsDirectory(
@@ -164,9 +159,9 @@ public class TestManager
 
             if (exampleArch == null)
             {
-                return printlnStatus(test.generate(generatorName, inputPath, cdr_version_, level == TestLevel.RUN));
+                return printlnStatus(test.generate(generatorName, inputPath, level == TestLevel.RUN));
             } else {
-                return printlnStatus(test.generate(generatorName, inputPath, exampleArch, cdr_version_, level == TestLevel.RUN));
+                return printlnStatus(test.generate(generatorName, inputPath, exampleArch, level == TestLevel.RUN));
             }
         }
 

--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -1773,7 +1773,7 @@ union_type [Vector<Annotation> annotations, ArrayList<Definition> defs] returns 
         LEFT_BRACE switch_body[unionTP] RIGHT_BRACE
         {
             // Calculate default label.
-            TemplateUtil.setUnionDefaultLabel(defs, unionTP, ctx.getScopeFile(), line);
+            TemplateUtil.find_and_set_default_discriminator_value(defs, unionTP);
 
             if(ctx.isInScopedFile() || ctx.isScopeLimitToAll())
             {
@@ -1862,7 +1862,7 @@ case_stmt [UnionTypeCode unionTP] returns [TemplateGroup tg = null]
 }
     :    ( KW_CASE const_exp
         {
-            labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator().getTypecode(), $const_exp.literalStr, ctx.getScopeFile(), _input.LT(1) != null ? _input.LT(1).getLine() - ctx.getCurrentIncludeLine() : 1));
+            labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator().getTypecode(), $const_exp.literalStr));
         } COLON
         | KW_DEFAULT { defaul = true; } COLON
         )+

--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -1845,7 +1845,7 @@ case_stmt [UnionTypeCode unionTP] returns [TemplateGroup tg = null]
 }
     :    ( KW_CASE const_exp
         {
-            labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator(), $const_exp.literalStr, ctx.getScopeFile(), _input.LT(1) != null ? _input.LT(1).getLine() - ctx.getCurrentIncludeLine() : 1));
+            labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator().getTypecode(), $const_exp.literalStr, ctx.getScopeFile(), _input.LT(1) != null ? _input.LT(1).getLine() - ctx.getCurrentIncludeLine() : 1));
         } COLON
         | KW_DEFAULT { defaul = true; } COLON
         )+

--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -177,27 +177,11 @@ module returns [Pair<com.eprosima.idl.parser.tree.Module, TemplateGroup> returnP
         if(moduleObject == null)
         {
             // Create the Module object.
-            moduleObject = new com.eprosima.idl.parser.tree.Module(ctx.getScopeFile(), ctx.isInScopedFile(), ctx.getScope(), name, tk);
-            //ctx.addPendingModule(moduleObject);
+            moduleObject = ctx.createModule(ctx.getScopeFile(), ctx.isInScopedFile(), ctx.getScope(), name, tk);
         }
 
-        // Add the module to the context.
-        ctx.addModule(moduleObject);
-
-        if(ctx.isInScopedFile() || ctx.isScopeLimitToAll()) {
-            if(tmanager != null) {
-                moduleTemplates = tmanager.createTemplateGroup("module");
-                moduleTemplates.setAttribute("ctx", ctx);
-                // Set the module object to the TemplateGroup of the module.
-                moduleTemplates.setAttribute("module", moduleObject);
-            }
-        }
-
-        // Update to a new namespace.
-        if(old_scope.isEmpty())
-            ctx.setScope(name);
-        else
-            ctx.setScope(old_scope + "::" + name);
+        // Add the module to the context and update to the new namespace (internally call ctx.setScope)
+        moduleTemplates = ctx.addModule(moduleObject);
     }
     // Each definition is stored in the Module and each TemplateGroup is set as attribute in the TemplateGroup of the module.
     LEFT_BRACE

--- a/src/main/antlr4/kiara/com/eprosima/idl/parser/grammar/KIARAIDL.g4
+++ b/src/main/antlr4/kiara/com/eprosima/idl/parser/grammar/KIARAIDL.g4
@@ -1218,7 +1218,7 @@ case_stmt [UnionTypeCode unionTP]
 }
 	:	( KW_CASE const_exp
 		{
-			labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator(), $const_exp.literalStr, ctx.getScopeFile(), _input.LT(1) != null ? _input.LT(1).getLine() - ctx.getCurrentIncludeLine() : 1));
+			labels.add(TemplateUtil.checkUnionLabel(unionTP.getDiscriminator().getTypecode(), $const_exp.literalStr, ctx.getScopeFile(), _input.LT(1) != null ? _input.LT(1).getLine() - ctx.getCurrentIncludeLine() : 1));
 		} COLON
 		| KW_DEFAULT { defaul = true; } COLON
 		)+

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -1415,6 +1415,11 @@ public class Context
         return generate_typesc_;
     }
 
+    public TemplateManager get_template_manager()
+    {
+        return tmanager_;
+    }
+
     // OS
     String m_os = null;
     String m_userdir = null;

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -72,6 +72,12 @@ import org.stringtemplate.v4.STGroupFile;
 
 public class Context
 {
+    /*!
+     * Built-in custom property to specify a TemplateGroup is using explicitly modules (in C++ when opening the
+     * namespace "namespace module {")
+     */
+    public static final String using_explicitly_modules_custom_property = "using_explicitly_modules";
+
     public Context(
             TemplateManager tmanager,
             String file,
@@ -1415,9 +1421,20 @@ public class Context
         return generate_typesc_;
     }
 
-    public TemplateManager get_template_manager()
+    /*!
+     * @brief Checks a custom property was enables for a TemplateGroup.
+     *
+     * There are built-in custom properties:
+     * - Context.using_explicitly_modules_custom_property: specifies a TemplateGroup is using explicitly modules.
+     */
+    public boolean is_enabled_custom_property_in_current_group(String custom_property)
     {
-        return tmanager_;
+        if (null != tmanager_)
+        {
+            return tmanager_.is_enabled_custom_property_in_current_group(custom_property);
+        }
+
+        return false;
     }
 
     // OS

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -211,7 +211,7 @@ public class Context
         autoidannenum.addMember(new EnumMember(Annotation.autoid_hash_str));
         autoidann.addMember(new AnnotationMember(Annotation.value_str, autoidannenum, Annotation.autoid_hash_str));
 
-        AnnotationDeclaration optionalann = createAnnotationDeclaration("optional", null);
+        AnnotationDeclaration optionalann = createAnnotationDeclaration(Annotation.optional_str, null);
         optionalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
         AnnotationDeclaration positionann = createAnnotationDeclaration("position", null);
@@ -262,7 +262,7 @@ public class Context
         AnnotationDeclaration bit_boundann = createAnnotationDeclaration("bit_bound", null);
         bit_boundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), "-1"));
 
-        AnnotationDeclaration externalann = createAnnotationDeclaration("external", null);
+        AnnotationDeclaration externalann = createAnnotationDeclaration(Annotation.external_str, null);
         externalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
         AnnotationDeclaration nestedann = createAnnotationDeclaration("nested", null);

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -14,6 +14,8 @@
 
 package com.eprosima.idl.context;
 
+import com.eprosima.idl.generator.manager.TemplateGroup;
+import com.eprosima.idl.generator.manager.TemplateManager;
 import com.eprosima.idl.parser.exception.ParseException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.AnnotationDeclaration;
@@ -63,6 +65,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import org.antlr.v4.runtime.Token;
+import org.stringtemplate.v4.STGroupFile;
 
 
 
@@ -70,9 +73,15 @@ import org.antlr.v4.runtime.Token;
 public class Context
 {
     public Context(
+            TemplateManager tmanager,
             String file,
-            ArrayList<String> includePaths)
+            ArrayList<String> includePaths,
+            boolean generate_typesc
+            )
     {
+        tmanager_ = tmanager;
+        generate_typesc_ = generate_typesc;
+
         // Detect OS
         m_os = System.getProperty("os.name");
         m_userdir = System.getProperty("user.dir");
@@ -120,7 +129,7 @@ public class Context
         m_scopeFilesStack = new Stack<Pair<String, Integer>>();
         for (int i = 0; i < includePaths.size(); ++i)
         {
-            String include = (String)includePaths.get(i);
+            String include = includePaths.get(i);
             if (startsWith(include, includeFlag))
             {
                 include = include.substring(includeFlag.length());
@@ -171,6 +180,20 @@ public class Context
                 ++pointer;
             }
         }
+
+        // Load IDL types for stringtemplates
+        TypeCode.ctx = this;
+        TypeCode.idltypesgr = new STGroupFile("com/eprosima/idl/templates/idlTypes.stg", '$', '$');
+        if (generate_typesc)
+        {
+            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/TypesCInterface.stg", '$', '$');
+        }
+        else
+        {
+            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/Types.stg", '$', '$');
+        }
+        TypeCode.ctypesgr = new STGroupFile("com/eprosima/idl/templates/CTypes.stg", '$', '$');
+        TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
 
         // Add here builtin annotations? (IDL 4.2 - 8.3.1 section)
         AnnotationDeclaration idann = createAnnotationDeclaration(Annotation.id_str, null);
@@ -377,13 +400,36 @@ public class Context
      * @brief This function adds a module to the context.
      * This function is used in the parser.
      */
-    public void addModule(
+    public TemplateGroup addModule(
             com.eprosima.idl.parser.tree.Module module)
     {
+        TemplateGroup moduleTemplates = null;
+
         if (!m_modules.containsKey(module.getScopedname()))
         {
             m_modules.put(module.getScopedname(), module);
         }
+
+        if(isInScopedFile() || isScopeLimitToAll()) {
+            if(tmanager_ != null) {
+                moduleTemplates = tmanager_.createTemplateGroup("module");
+                moduleTemplates.setAttribute("ctx", this);
+                // Set the module object to the TemplateGroup of the module.
+                moduleTemplates.setAttribute("module", module);
+            }
+        }
+
+        // Change context scope.
+        if (m_scope.isEmpty())
+        {
+            setScope(module.getName());
+        }
+        else
+        {
+            setScope(m_scope + "::" + module.getName());
+        }
+
+        return moduleTemplates;
     }
 
     public com.eprosima.idl.parser.tree.Module existsModule(
@@ -531,6 +577,16 @@ public class Context
         }
 
         return returnedValue;
+    }
+
+    public com.eprosima.idl.parser.tree.Module createModule(
+            String scope_file,
+            boolean is_in_scope,
+            String scope,
+            String name,
+            Token token)
+    {
+        return new com.eprosima.idl.parser.tree.Module (scope_file, is_in_scope, scope, name, token);
     }
 
     public Operation createOperation(
@@ -690,7 +746,7 @@ public class Context
         TypeCode returnedValue = null;
         TypeDeclaration typedecl = m_types.get(name);
 
-        // Probar si no tiene scope, con el scope actual.
+        // Wether the name doesn't contain scope, test with the current scope.
         if (typedecl == null)
         {
             String scope = m_scope;
@@ -1354,6 +1410,11 @@ public class Context
         return aux_str;
     }
 
+    public boolean isGenerateTypesC()
+    {
+        return generate_typesc_;
+    }
+
     // OS
     String m_os = null;
     String m_userdir = null;
@@ -1404,4 +1465,8 @@ public class Context
     private HashSet<String> m_keywords = null;
 
     private boolean m_ignore_case = true;
+
+    private boolean generate_typesc_ = false;
+
+    protected TemplateManager tmanager_ = null;
 }

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -33,6 +33,7 @@ import com.eprosima.idl.parser.typecode.ArrayTypeCode;
 import com.eprosima.idl.parser.typecode.BitfieldSpec;
 import com.eprosima.idl.parser.typecode.BitsetTypeCode;
 import com.eprosima.idl.parser.typecode.BitmaskTypeCode;
+import com.eprosima.idl.parser.typecode.Bitmask;
 import com.eprosima.idl.parser.typecode.EnumMember;
 import com.eprosima.idl.parser.typecode.EnumTypeCode;
 import com.eprosima.idl.parser.typecode.Kind;
@@ -201,9 +202,9 @@ public class Context
         TypeCode.ctypesgr = new STGroupFile("com/eprosima/idl/templates/CTypes.stg", '$', '$');
         TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
 
-        // Add here builtin annotations? (IDL 4.2 - 8.3.1 section)
+        // Builtin annotations (IDL 4.2 - 8.3 section & XTypes 1.3 - 7.3.1.2.1 section)
         AnnotationDeclaration idann = createAnnotationDeclaration(Annotation.id_str, null);
-        idann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_LONG), "-1"));
+        idann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_ULONG), Annotation.null_default_value));
 
         AnnotationDeclaration autoidann = createAnnotationDeclaration(Annotation.autoid_str, null);
         EnumTypeCode autoidannenum = new EnumTypeCode(autoidann.getScopedname(), Annotation.autoid_enum_str);
@@ -212,10 +213,10 @@ public class Context
         autoidann.addMember(new AnnotationMember(Annotation.value_str, autoidannenum, Annotation.autoid_hash_str));
 
         AnnotationDeclaration optionalann = createAnnotationDeclaration(Annotation.optional_str, null);
-        optionalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        optionalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        AnnotationDeclaration positionann = createAnnotationDeclaration("position", null);
-        positionann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), "-1"));
+        AnnotationDeclaration positionann = createAnnotationDeclaration(Annotation.position_str, null);
+        positionann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), Annotation.null_default_value));
 
         AnnotationDeclaration valueann = createAnnotationDeclaration(Annotation.value_str, null);
         valueann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
@@ -232,71 +233,101 @@ public class Context
         createAnnotationDeclaration(Annotation.appendable_str, null);
         createAnnotationDeclaration(Annotation.mutable_str, null);
 
-        // Create default @Key annotation.
+        // Create default @key annotation (@Key annotation also supported and registered in parseIDL)
         AnnotationDeclaration keyann = createAnnotationDeclaration(Annotation.key_str, null);
-        keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        AnnotationDeclaration mustundann = createAnnotationDeclaration("must_understand", null);
-        mustundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        AnnotationDeclaration mustundann = createAnnotationDeclaration(Annotation.must_understand_str, null);
+        mustundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        createAnnotationDeclaration("default_literal", null);
+        createAnnotationDeclaration(Annotation.default_literal_str, null);
 
-        AnnotationDeclaration rangeann = createAnnotationDeclaration("range", null);
-        rangeann.addMember(new AnnotationMember("min", new AnyTypeCode(), null));
-        //String.valueOf(Integer.MIN_VALUE)));
-        rangeann.addMember(new AnnotationMember("max", new AnyTypeCode(), null));
-        //String.valueOf(Integer.MAX_VALUE)));
-
-        AnnotationDeclaration unitsann = createAnnotationDeclaration("units", null);
-        unitsann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_STRING), ""));
-
-        AnnotationDeclaration defaultann = createAnnotationDeclaration("default", null);
+        AnnotationDeclaration defaultann = createAnnotationDeclaration(Annotation.default_str, null);
         defaultann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
 
-        AnnotationDeclaration minann = createAnnotationDeclaration("min", null);
+        AnnotationDeclaration rangeann = createAnnotationDeclaration(Annotation.range_str, null);
+        rangeann.addMember(new AnnotationMember(Annotation.min_str, new AnyTypeCode(), null));
+        rangeann.addMember(new AnnotationMember(Annotation.max_str, new AnyTypeCode(), null));
+
+        AnnotationDeclaration minann = createAnnotationDeclaration(Annotation.min_str, null);
         minann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
 
-        AnnotationDeclaration maxann = createAnnotationDeclaration("max", null);
+        AnnotationDeclaration maxann = createAnnotationDeclaration(Annotation.max_str, null);
         maxann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
 
-        AnnotationDeclaration bit_boundann = createAnnotationDeclaration("bit_bound", null);
-        bit_boundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), "-1"));
+        AnnotationDeclaration unitsann = createAnnotationDeclaration(Annotation.unit_str, null);
+        unitsann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
+
+        AnnotationDeclaration bit_boundann = createAnnotationDeclaration(Annotation.bit_bound_str, null);
+        bit_boundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), Annotation.null_default_value));
 
         AnnotationDeclaration externalann = createAnnotationDeclaration(Annotation.external_str, null);
-        externalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        externalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        AnnotationDeclaration nestedann = createAnnotationDeclaration("nested", null);
-        nestedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        AnnotationDeclaration nestedann = createAnnotationDeclaration(Annotation.nested_str, null);
+        nestedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        AnnotationDeclaration verbatimann = createAnnotationDeclaration("verbatim", null);
-        EnumTypeCode verbatimannenum = new EnumTypeCode(verbatimann.getScopedname(), "verbatimannenum");
-        verbatimannenum.addMember(new EnumMember("BEGIN_FILE"));
-        verbatimannenum.addMember(new EnumMember("BEFORE_DECLARATION"));
-        verbatimannenum.addMember(new EnumMember("BEGIN_DECLARATION"));
-        verbatimannenum.addMember(new EnumMember("END_DECLARATION"));
-        verbatimannenum.addMember(new EnumMember("AFTER_DECLARATION"));
-        verbatimannenum.addMember(new EnumMember("END_FILE"));
-        verbatimann.addMember(new AnnotationMember("language", new PrimitiveTypeCode(Kind.KIND_STRING), "*"));
+        AnnotationDeclaration verbatimann = createAnnotationDeclaration(Annotation.verbatim_str, null);
+        EnumTypeCode verbatimannenum = new EnumTypeCode(verbatimann.getScopedname(), Annotation.placement_enum_str);
+        verbatimannenum.addMember(new EnumMember(Annotation.begin_file_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.before_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.begin_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.end_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.after_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.end_file_str));
+        verbatimann.addMember(new AnnotationMember(Annotation.language_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
         // c, c++, java, idl, * (any), or custom value
-        verbatimann.addMember(new AnnotationMember("placement", verbatimannenum, "BEFORE_DECLARATION"));
-        verbatimann.addMember(new AnnotationMember("text", new PrimitiveTypeCode(Kind.KIND_STRING), ""));
+        verbatimann.addMember(new AnnotationMember(Annotation.placement_str, verbatimannenum, Annotation.before_declaration_str));
+        verbatimann.addMember(new AnnotationMember(Annotation.text_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
 
-        AnnotationDeclaration serviceann = createAnnotationDeclaration("service", null);
-        serviceann.addMember(new AnnotationMember("platform", new PrimitiveTypeCode(Kind.KIND_STRING), "*"));
+        AnnotationDeclaration serviceann = createAnnotationDeclaration(Annotation.service_str, null);
+        serviceann.addMember(new AnnotationMember(Annotation.platform_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
         // CORBA, DDS, * (any), or custom value
 
-        AnnotationDeclaration onewayann = createAnnotationDeclaration("oneway", null);
-        onewayann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        AnnotationDeclaration onewayann = createAnnotationDeclaration(Annotation.oneway_str, null);
+        onewayann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
-        AnnotationDeclaration amiann = createAnnotationDeclaration("ami", null);
-        amiann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        AnnotationDeclaration amiann = createAnnotationDeclaration(Annotation.ami_str, null);
+        amiann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
 
         AnnotationDeclaration hashid_annotation = createAnnotationDeclaration(Annotation.hashid_str, null);
-        hashid_annotation.addMember(new AnnotationMember(Annotation.value_str, new StringTypeCode(Kind.KIND_STRING, null, null), ""));
+        hashid_annotation.addMember(new AnnotationMember(Annotation.value_str, new StringTypeCode(Kind.KIND_STRING, null, null), Annotation.empty_str));
+
+        AnnotationDeclaration default_nested_annotation = createAnnotationDeclaration(Annotation.default_nested_str, null);
+        default_nested_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+
+        AnnotationDeclaration ignore_literal_names_annotation = createAnnotationDeclaration(Annotation.ignore_literal_names_str, null);
+        ignore_literal_names_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+
+        EnumTypeCode try_construct_fail_action_enum = new EnumTypeCode(null, Annotation.try_construct_enum_str);
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_discard_str));
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_use_default_str));
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_trim_str));
+
+        AnnotationDeclaration try_construct_annotation = createAnnotationDeclaration(Annotation.try_construct_str, null);
+        try_construct_annotation.addMember(new AnnotationMember(Annotation.value_str, try_construct_fail_action_enum, Annotation.try_construct_use_default_str));
 
         // Create default @non_serialized annotation.
-        AnnotationDeclaration non_serializedann = createAnnotationDeclaration("non_serialized", null);
-        non_serializedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
+        AnnotationDeclaration non_serializedann = createAnnotationDeclaration(Annotation.non_serialized_str, null);
+        non_serializedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+
+        BitmaskTypeCode data_representation_mask_bitmask = new BitmaskTypeCode(null, Annotation.data_representation_mask_str);
+        Bitmask xcdr1_bitmask = new Bitmask(data_representation_mask_bitmask, Annotation.xcdr1_bitflag_str);
+        xcdr1_bitmask.setPosition(0);
+        data_representation_mask_bitmask.addBitmask(xcdr1_bitmask);
+        Bitmask xml_bitmask = new Bitmask(data_representation_mask_bitmask, Annotation.xml_bitflag_str);
+        xml_bitmask.setPosition(1);
+        data_representation_mask_bitmask.addBitmask(xml_bitmask);
+        Bitmask xcdr2_bitmask = new Bitmask(data_representation_mask_bitmask, Annotation.xcdr2_bitflag_str);
+        xcdr2_bitmask.setPosition(2);
+        data_representation_mask_bitmask.addBitmask(xcdr2_bitmask);
+
+        AnnotationDeclaration data_representation_annotation = createAnnotationDeclaration(Annotation.data_representation_str, null);
+        data_representation_annotation.addMember(new AnnotationMember(Annotation.allowed_kinds_str, data_representation_mask_bitmask, Annotation.empty_str));
+
+        AnnotationDeclaration topic_annotation = createAnnotationDeclaration(Annotation.topic_str, null);
+        topic_annotation.addMember(new AnnotationMember(Annotation.name_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
+        topic_annotation.addMember(new AnnotationMember(Annotation.platform_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
     }
 
     public String getFilename()

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -14,39 +14,6 @@
 
 package com.eprosima.idl.context;
 
-import com.eprosima.idl.generator.manager.TemplateGroup;
-import com.eprosima.idl.generator.manager.TemplateManager;
-import com.eprosima.idl.parser.exception.ParseException;
-import com.eprosima.idl.parser.tree.Annotation;
-import com.eprosima.idl.parser.tree.AnnotationDeclaration;
-import com.eprosima.idl.parser.tree.AnnotationMember;
-import com.eprosima.idl.parser.tree.ConstDeclaration;
-import com.eprosima.idl.parser.tree.Definition;
-import com.eprosima.idl.parser.tree.Interface;
-import com.eprosima.idl.parser.tree.Operation;
-import com.eprosima.idl.parser.tree.Param;
-import com.eprosima.idl.parser.tree.TypeDeclaration;
-import com.eprosima.idl.parser.tree.TreeNode;
-import com.eprosima.idl.parser.typecode.AliasTypeCode;
-import com.eprosima.idl.parser.typecode.AnyTypeCode;
-import com.eprosima.idl.parser.typecode.ArrayTypeCode;
-import com.eprosima.idl.parser.typecode.BitfieldSpec;
-import com.eprosima.idl.parser.typecode.BitsetTypeCode;
-import com.eprosima.idl.parser.typecode.BitmaskTypeCode;
-import com.eprosima.idl.parser.typecode.Bitmask;
-import com.eprosima.idl.parser.typecode.EnumMember;
-import com.eprosima.idl.parser.typecode.EnumTypeCode;
-import com.eprosima.idl.parser.typecode.Kind;
-import com.eprosima.idl.parser.typecode.MapTypeCode;
-import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
-import com.eprosima.idl.parser.typecode.SequenceTypeCode;
-import com.eprosima.idl.parser.typecode.SetTypeCode;
-import com.eprosima.idl.parser.typecode.StringTypeCode;
-import com.eprosima.idl.parser.typecode.StructTypeCode;
-import com.eprosima.idl.parser.typecode.TypeCode;
-import com.eprosima.idl.parser.typecode.UnionTypeCode;
-import com.eprosima.idl.util.Pair;
-import com.eprosima.idl.util.Util;
 import java.io.File;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -68,8 +35,39 @@ import javax.script.ScriptException;
 import org.antlr.v4.runtime.Token;
 import org.stringtemplate.v4.STGroupFile;
 
-
-
+import com.eprosima.idl.generator.manager.TemplateGroup;
+import com.eprosima.idl.generator.manager.TemplateManager;
+import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.idl.parser.tree.Annotation;
+import com.eprosima.idl.parser.tree.AnnotationDeclaration;
+import com.eprosima.idl.parser.tree.AnnotationMember;
+import com.eprosima.idl.parser.tree.ConstDeclaration;
+import com.eprosima.idl.parser.tree.Definition;
+import com.eprosima.idl.parser.tree.Interface;
+import com.eprosima.idl.parser.tree.Operation;
+import com.eprosima.idl.parser.tree.Param;
+import com.eprosima.idl.parser.tree.TypeDeclaration;
+import com.eprosima.idl.parser.tree.TreeNode;
+import com.eprosima.idl.parser.typecode.AliasTypeCode;
+import com.eprosima.idl.parser.typecode.AnyTypeCode;
+import com.eprosima.idl.parser.typecode.ArrayTypeCode;
+import com.eprosima.idl.parser.typecode.BitfieldSpec;
+import com.eprosima.idl.parser.typecode.BitsetTypeCode;
+import com.eprosima.idl.parser.typecode.Bitmask;
+import com.eprosima.idl.parser.typecode.BitmaskTypeCode;
+import com.eprosima.idl.parser.typecode.EnumMember;
+import com.eprosima.idl.parser.typecode.EnumTypeCode;
+import com.eprosima.idl.parser.typecode.Kind;
+import com.eprosima.idl.parser.typecode.MapTypeCode;
+import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
+import com.eprosima.idl.parser.typecode.SequenceTypeCode;
+import com.eprosima.idl.parser.typecode.SetTypeCode;
+import com.eprosima.idl.parser.typecode.StringTypeCode;
+import com.eprosima.idl.parser.typecode.StructTypeCode;
+import com.eprosima.idl.parser.typecode.TypeCode;
+import com.eprosima.idl.parser.typecode.UnionTypeCode;
+import com.eprosima.idl.util.Pair;
+import com.eprosima.idl.util.Util;
 
 public class Context
 {
@@ -203,114 +201,26 @@ public class Context
         TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
 
         // Builtin annotations (IDL 4.2 - 8.3 section & XTypes 1.3 - 7.3.1.2.1 section)
-        AnnotationDeclaration idann = createAnnotationDeclaration(Annotation.id_str, null);
-        idann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_ULONG), Annotation.null_default_value));
 
+        //{{{ @ami
+        AnnotationDeclaration amiann = createAnnotationDeclaration(Annotation.ami_str, null);
+        amiann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @autoid
         AnnotationDeclaration autoidann = createAnnotationDeclaration(Annotation.autoid_str, null);
         EnumTypeCode autoidannenum = new EnumTypeCode(autoidann.getScopedname(), Annotation.autoid_enum_str);
         autoidannenum.addMember(new EnumMember(Annotation.autoid_sequential_str));
         autoidannenum.addMember(new EnumMember(Annotation.autoid_hash_str));
         autoidann.addMember(new AnnotationMember(Annotation.value_str, autoidannenum, Annotation.autoid_hash_str));
+        //}}}
 
-        AnnotationDeclaration optionalann = createAnnotationDeclaration(Annotation.optional_str, null);
-        optionalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration positionann = createAnnotationDeclaration(Annotation.position_str, null);
-        positionann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), Annotation.null_default_value));
-
-        AnnotationDeclaration valueann = createAnnotationDeclaration(Annotation.value_str, null);
-        valueann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
-
-        AnnotationDeclaration extensibilityann = createAnnotationDeclaration(Annotation.extensibility_str, null);
-        EnumTypeCode extensibilityannenum = new EnumTypeCode(extensibilityann.getScopedname(), Annotation.extensibility_enum_str);
-        extensibilityannenum.addMember(new EnumMember(Annotation.ex_final_str));
-        extensibilityannenum.addMember(new EnumMember(Annotation.ex_appendable_str));
-        extensibilityannenum.addMember(new EnumMember(Annotation.ex_mutable_str));
-        extensibilityann.addMember(new AnnotationMember(Annotation.value_str, extensibilityannenum,
-                extensibilityannenum.getInitialValue()));
-
-        createAnnotationDeclaration(Annotation.final_str, null);
-        createAnnotationDeclaration(Annotation.appendable_str, null);
-        createAnnotationDeclaration(Annotation.mutable_str, null);
-
-        // Create default @key annotation (@Key annotation also supported and registered in parseIDL)
-        AnnotationDeclaration keyann = createAnnotationDeclaration(Annotation.key_str, null);
-        keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration mustundann = createAnnotationDeclaration(Annotation.must_understand_str, null);
-        mustundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        createAnnotationDeclaration(Annotation.default_literal_str, null);
-
-        AnnotationDeclaration defaultann = createAnnotationDeclaration(Annotation.default_str, null);
-        defaultann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
-
-        AnnotationDeclaration rangeann = createAnnotationDeclaration(Annotation.range_str, null);
-        rangeann.addMember(new AnnotationMember(Annotation.min_str, new AnyTypeCode(), null));
-        rangeann.addMember(new AnnotationMember(Annotation.max_str, new AnyTypeCode(), null));
-
-        AnnotationDeclaration minann = createAnnotationDeclaration(Annotation.min_str, null);
-        minann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
-
-        AnnotationDeclaration maxann = createAnnotationDeclaration(Annotation.max_str, null);
-        maxann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
-
-        AnnotationDeclaration unitsann = createAnnotationDeclaration(Annotation.unit_str, null);
-        unitsann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
-
+        //{{{ @bit_bound
         AnnotationDeclaration bit_boundann = createAnnotationDeclaration(Annotation.bit_bound_str, null);
         bit_boundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), Annotation.null_default_value));
+        //}}}
 
-        AnnotationDeclaration externalann = createAnnotationDeclaration(Annotation.external_str, null);
-        externalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration nestedann = createAnnotationDeclaration(Annotation.nested_str, null);
-        nestedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration verbatimann = createAnnotationDeclaration(Annotation.verbatim_str, null);
-        EnumTypeCode verbatimannenum = new EnumTypeCode(verbatimann.getScopedname(), Annotation.placement_enum_str);
-        verbatimannenum.addMember(new EnumMember(Annotation.begin_file_str));
-        verbatimannenum.addMember(new EnumMember(Annotation.before_declaration_str));
-        verbatimannenum.addMember(new EnumMember(Annotation.begin_declaration_str));
-        verbatimannenum.addMember(new EnumMember(Annotation.end_declaration_str));
-        verbatimannenum.addMember(new EnumMember(Annotation.after_declaration_str));
-        verbatimannenum.addMember(new EnumMember(Annotation.end_file_str));
-        verbatimann.addMember(new AnnotationMember(Annotation.language_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
-        // c, c++, java, idl, * (any), or custom value
-        verbatimann.addMember(new AnnotationMember(Annotation.placement_str, verbatimannenum, Annotation.before_declaration_str));
-        verbatimann.addMember(new AnnotationMember(Annotation.text_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
-
-        AnnotationDeclaration serviceann = createAnnotationDeclaration(Annotation.service_str, null);
-        serviceann.addMember(new AnnotationMember(Annotation.platform_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
-        // CORBA, DDS, * (any), or custom value
-
-        AnnotationDeclaration onewayann = createAnnotationDeclaration(Annotation.oneway_str, null);
-        onewayann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration amiann = createAnnotationDeclaration(Annotation.ami_str, null);
-        amiann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration hashid_annotation = createAnnotationDeclaration(Annotation.hashid_str, null);
-        hashid_annotation.addMember(new AnnotationMember(Annotation.value_str, new StringTypeCode(Kind.KIND_STRING, null, null), Annotation.empty_str));
-
-        AnnotationDeclaration default_nested_annotation = createAnnotationDeclaration(Annotation.default_nested_str, null);
-        default_nested_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        AnnotationDeclaration ignore_literal_names_annotation = createAnnotationDeclaration(Annotation.ignore_literal_names_str, null);
-        ignore_literal_names_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
-        EnumTypeCode try_construct_fail_action_enum = new EnumTypeCode(null, Annotation.try_construct_enum_str);
-        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_discard_str));
-        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_use_default_str));
-        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_trim_str));
-
-        AnnotationDeclaration try_construct_annotation = createAnnotationDeclaration(Annotation.try_construct_str, null);
-        try_construct_annotation.addMember(new AnnotationMember(Annotation.value_str, try_construct_fail_action_enum, Annotation.try_construct_use_default_str));
-
-        // Create default @non_serialized annotation.
-        AnnotationDeclaration non_serializedann = createAnnotationDeclaration(Annotation.non_serialized_str, null);
-        non_serializedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
-
+        //{{{ @data_representation
         BitmaskTypeCode data_representation_mask_bitmask = new BitmaskTypeCode(null, Annotation.data_representation_mask_str);
         Bitmask xcdr1_bitmask = new Bitmask(data_representation_mask_bitmask, Annotation.xcdr1_bitflag_str);
         xcdr1_bitmask.setPosition(0);
@@ -324,10 +234,154 @@ public class Context
 
         AnnotationDeclaration data_representation_annotation = createAnnotationDeclaration(Annotation.data_representation_str, null);
         data_representation_annotation.addMember(new AnnotationMember(Annotation.allowed_kinds_str, data_representation_mask_bitmask, Annotation.empty_str));
+        //}}}
 
+        //{{{ @default
+        AnnotationDeclaration defaultann = createAnnotationDeclaration(Annotation.default_str, null);
+        defaultann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
+        //}}}
+
+        //{{{ @default_literal
+        createAnnotationDeclaration(Annotation.default_literal_str, null);
+        //}}}
+
+        //{{{ @default_nested
+        AnnotationDeclaration default_nested_annotation = createAnnotationDeclaration(Annotation.default_nested_str, null);
+        default_nested_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @extensibility
+        AnnotationDeclaration extensibilityann = createAnnotationDeclaration(Annotation.extensibility_str, null);
+        EnumTypeCode extensibilityannenum = new EnumTypeCode(extensibilityann.getScopedname(), Annotation.extensibility_enum_str);
+        extensibilityannenum.addMember(new EnumMember(Annotation.ex_final_str));
+        extensibilityannenum.addMember(new EnumMember(Annotation.ex_appendable_str));
+        extensibilityannenum.addMember(new EnumMember(Annotation.ex_mutable_str));
+        extensibilityann.addMember(new AnnotationMember(Annotation.value_str, extensibilityannenum,
+                extensibilityannenum.getInitialValue()));
+
+        createAnnotationDeclaration(Annotation.final_str, null);
+        createAnnotationDeclaration(Annotation.appendable_str, null);
+        createAnnotationDeclaration(Annotation.mutable_str, null);
+        //}}}
+
+        //{{{ @external
+        AnnotationDeclaration externalann = createAnnotationDeclaration(Annotation.external_str, null);
+        externalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @hashid
+        AnnotationDeclaration hashid_annotation = createAnnotationDeclaration(Annotation.hashid_str, null);
+        hashid_annotation.addMember(new AnnotationMember(Annotation.value_str, new StringTypeCode(Kind.KIND_STRING, null, null), Annotation.empty_str));
+        //}}}
+
+        //{{{ @id
+        AnnotationDeclaration idann = createAnnotationDeclaration(Annotation.id_str, null);
+        idann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_ULONG), Annotation.null_default_value));
+        //}}}
+
+        //{{{ @ignore_literal_names
+        AnnotationDeclaration ignore_literal_names_annotation = createAnnotationDeclaration(Annotation.ignore_literal_names_str, null);
+        ignore_literal_names_annotation.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @key
+        // Create default @key annotation (@Key annotation also supported and registered in parseIDL)
+        AnnotationDeclaration keyann = createAnnotationDeclaration(Annotation.key_str, null);
+        keyann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @max
+        AnnotationDeclaration maxann = createAnnotationDeclaration(Annotation.max_str, null);
+        maxann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
+        //}}}
+
+        //{{{ @min
+        AnnotationDeclaration minann = createAnnotationDeclaration(Annotation.min_str, null);
+        minann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
+        //}}}
+
+        //{{{ @must_understand
+        AnnotationDeclaration mustundann = createAnnotationDeclaration(Annotation.must_understand_str, null);
+        mustundann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @nested
+        AnnotationDeclaration nestedann = createAnnotationDeclaration(Annotation.nested_str, null);
+        nestedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @non_serialized
+        AnnotationDeclaration non_serializedann = createAnnotationDeclaration(Annotation.non_serialized_str, null);
+        non_serializedann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @oneway
+        AnnotationDeclaration onewayann = createAnnotationDeclaration(Annotation.oneway_str, null);
+        onewayann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @optional
+        AnnotationDeclaration optionalann = createAnnotationDeclaration(Annotation.optional_str, null);
+        optionalann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_BOOLEAN), Annotation.true_str));
+        //}}}
+
+        //{{{ @position
+        AnnotationDeclaration positionann = createAnnotationDeclaration(Annotation.position_str, null);
+        positionann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_USHORT), Annotation.null_default_value));
+        //}}}
+
+        //{{{ @range
+        AnnotationDeclaration rangeann = createAnnotationDeclaration(Annotation.range_str, null);
+        rangeann.addMember(new AnnotationMember(Annotation.min_str, new AnyTypeCode(), null));
+        rangeann.addMember(new AnnotationMember(Annotation.max_str, new AnyTypeCode(), null));
+        //}}}
+
+        //{{{ @service
+        AnnotationDeclaration serviceann = createAnnotationDeclaration(Annotation.service_str, null);
+        serviceann.addMember(new AnnotationMember(Annotation.platform_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
+        // CORBA, DDS, * (any), or custom value
+        //}}}
+
+        //{{{ topic
         AnnotationDeclaration topic_annotation = createAnnotationDeclaration(Annotation.topic_str, null);
         topic_annotation.addMember(new AnnotationMember(Annotation.name_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
         topic_annotation.addMember(new AnnotationMember(Annotation.platform_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
+        //}}}
+
+        //{{{ @try_construct
+        EnumTypeCode try_construct_fail_action_enum = new EnumTypeCode(null, Annotation.try_construct_enum_str);
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_discard_str));
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_use_default_str));
+        try_construct_fail_action_enum.addMember(new EnumMember(Annotation.try_construct_trim_str));
+
+        AnnotationDeclaration try_construct_annotation = createAnnotationDeclaration(Annotation.try_construct_str, null);
+        try_construct_annotation.addMember(new AnnotationMember(Annotation.value_str, try_construct_fail_action_enum, Annotation.try_construct_use_default_str));
+        //}}}
+
+        //{{{ @unit
+        AnnotationDeclaration unitsann = createAnnotationDeclaration(Annotation.unit_str, null);
+        unitsann.addMember(new AnnotationMember(Annotation.value_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
+        //}}}
+
+        //{{{ @value
+        AnnotationDeclaration valueann = createAnnotationDeclaration(Annotation.value_str, null);
+        valueann.addMember(new AnnotationMember(Annotation.value_str, new AnyTypeCode(), null));
+        //}}}
+
+        //{{{ @verbatim
+        AnnotationDeclaration verbatimann = createAnnotationDeclaration(Annotation.verbatim_str, null);
+        EnumTypeCode verbatimannenum = new EnumTypeCode(verbatimann.getScopedname(), Annotation.placement_enum_str);
+        verbatimannenum.addMember(new EnumMember(Annotation.begin_file_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.before_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.begin_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.end_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.after_declaration_str));
+        verbatimannenum.addMember(new EnumMember(Annotation.end_file_str));
+        verbatimann.addMember(new AnnotationMember(Annotation.language_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.any_str));
+        // c, c++, java, idl, * (any), or custom value
+        verbatimann.addMember(new AnnotationMember(Annotation.placement_str, verbatimannenum, Annotation.before_declaration_str));
+        verbatimann.addMember(new AnnotationMember(Annotation.text_str, new PrimitiveTypeCode(Kind.KIND_STRING), Annotation.empty_str));
+        //}}}
     }
 
     public String getFilename()

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateGroup.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateGroup.java
@@ -31,42 +31,44 @@ import com.eprosima.log.Log;
 
 public class TemplateGroup
 {
-    private Map<String, ST> m_templates = new HashMap<String, ST>();
+    private Map<String, TemplateST> m_templates = new HashMap<String, TemplateST>();
     private Map<String, List<ST>> m_extensionstemplates = new HashMap<String, List<ST>>();
     private TemplateErrorListener error_listener_ = null;
+    private TemplateManager manager_ = null;
 
     public TemplateGroup(TemplateManager manager)
     {
+        manager_ = manager;
         error_listener_ = new TemplateErrorListener(manager);
     }
 
-    public void addTemplate(String groupname, ST template)
+    public void addTemplate(String groupname, TemplateST template)
     {
         m_templates.put(groupname, template);
     }
 
-    public void addTemplate(String groupname, ST template, List<ST> extensionstemplates)
+    public void addTemplate(String groupname, TemplateST template, List<ST> extensionstemplates)
     {
         addTemplate(groupname, template);
-        m_extensionstemplates.put(groupname + "_" + template.getName(), extensionstemplates);
+        m_extensionstemplates.put(groupname + "_" + template.get_st().getName(), extensionstemplates);
     }
 
-    public ST getTemplate(String groupname)
+    public TemplateST getTemplate(String groupname)
     {
-        ST template = m_templates.get(groupname);
+        TemplateST template = m_templates.get(groupname);
 
         //If there is extensiones, add them before return the template.
-        if(m_extensionstemplates.containsKey(groupname + "_" + template.getName()))
+        if(m_extensionstemplates.containsKey(groupname + "_" + template.get_st().getName()))
         {
             List<ST> extemplates = new ArrayList<ST>();
-            List<ST> extensions = m_extensionstemplates.get(groupname + "_" + template.getName());
+            List<ST> extensions = m_extensionstemplates.get(groupname + "_" + template.get_st().getName());
 
             for(ST extension : extensions)
             {
                 extemplates.add(extension);
             }
 
-            template.add("extensions", extemplates);
+            template.get_st().add("extensions", extemplates);
         }
 
         return template;
@@ -76,23 +78,30 @@ public class TemplateGroup
     {
         if(tg != null)
         {
-            Set<Entry<String, ST>> set = m_templates.entrySet();
-            Iterator<Entry<String, ST>> it = set.iterator();
+            Set<Entry<String, TemplateST>> set = m_templates.entrySet();
+            Iterator<Entry<String, TemplateST>> it = set.iterator();
 
             while(it.hasNext())
             {
-                Map.Entry<String, ST> m = it.next();
+                Map.Entry<String, TemplateST> m = it.next();
 
                 // Call setAttribute
-                ST template = tg.getTemplate(m.getKey());
+                TemplateST template = tg.getTemplate(m.getKey());
 
                 if(template != null)
                 {
-                    Log.printDebug("setting attribute (TemplateGroup) to template group " + m.getKey() + " from " + template.getName() + " to " + m.getValue().getName());
+                    // Before render, set the current TemplateSTGroup in TemplateManager.
+                    manager_.set_current_template_stgroup(m.getValue().get_template_stgroup());
+
+                    Log.printDebug("setting attribute (TemplateGroup) to template group " + m.getKey() + " from " +
+                            template.get_st().getName() + " to " + m.getValue().get_st().getName());
                     StringWriter out = new StringWriter();
                     STWriter wr = new AutoIndentWriter(out);
-                    template.write(wr, error_listener_);
-                    m.getValue().add(attribute, out.toString());
+                    template.get_st().write(wr, error_listener_);
+                    m.getValue().get_st().add(attribute, out.toString());
+
+                    // Unset the current TemplateSTGroup in TemplateManager.
+                    manager_.set_current_template_stgroup(null);
                 }
             }
         }
@@ -100,19 +109,20 @@ public class TemplateGroup
 
     public void setAttribute(String attribute, Object obj1)
     {
-        Set<Entry<String, ST>> set = m_templates.entrySet();
-        Iterator<Entry<String, ST>> it = set.iterator();
+        Set<Entry<String, TemplateST>> set = m_templates.entrySet();
+        Iterator<Entry<String, TemplateST>> it = set.iterator();
 
         while(it.hasNext())
         {
-            Map.Entry<String, ST> m = it.next();
+            Map.Entry<String, TemplateST> m = it.next();
 
             // Call setAttribute
-            Log.printDebug("setting attribute (obj1) to template group " + m.getKey() + " to " + m.getValue().getName());
-            ST template = m.getValue();
-            template.add(attribute, obj1);
+            Log.printDebug("setting attribute (obj1) to template group " + m.getKey() + " to " +
+                    m.getValue().get_st().getName());
+            TemplateST template = m.getValue();
+            template.get_st().add(attribute, obj1);
             // Update extensions
-            List<ST> extensions = m_extensionstemplates.get(m.getKey() + "_" + template.getName());
+            List<ST> extensions = m_extensionstemplates.get(m.getKey() + "_" + template.get_st().getName());
             if(extensions != null)
             {
                 for(ST extension : extensions)

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
@@ -29,34 +29,38 @@ import org.stringtemplate.v4.misc.STMessage;
 
 public class TemplateManager
 {
-    private Map<String, STGroup> m_groups = new HashMap<String, STGroup>();
+    private Map<String, TemplateSTGroup> m_groups = new HashMap<String, TemplateSTGroup>();
 
     private boolean st_error_ = false;
 
-    public void addGroup(String groupname)
+    private TemplateSTGroup current_template_stgroup_ = null;
+
+    public TemplateSTGroup addGroup(String groupname)
     {
-        STGroup group = new STGroupFile(groupname, '$', '$');
+        TemplateSTGroup group = new TemplateSTGroup(groupname);
         m_groups.put(groupname, group);
+        return group;
     }
 
-    public void addGroupFromString(String groupname, String text)
+    public TemplateSTGroup addGroupFromString(String groupname, String text)
     {
-        STGroup group = new STGroupString(groupname, text, '$', '$');
+        TemplateSTGroup group = new TemplateSTGroup(groupname, text);
         m_groups.put(groupname, group);
+        return group;
     }
 
     public TemplateGroup createTemplateGroup(String templatename)
     {
         TemplateGroup tg = new TemplateGroup(this);
-        Set<Entry<String, STGroup>> set = m_groups.entrySet();
-        Iterator<Entry<String, STGroup>> it = set.iterator();
+        Set<Entry<String, TemplateSTGroup>> set = m_groups.entrySet();
+        Iterator<Entry<String, TemplateSTGroup>> it = set.iterator();
 
         while(it.hasNext())
         {
-            Map.Entry<String, STGroup> m = it.next();
+            Map.Entry<String, TemplateSTGroup> m = it.next();
 
             // Obtain instance
-            ST template = m.getValue().getInstanceOf(templatename);
+            TemplateST template = new TemplateST(m.getValue(), templatename);
             tg.addTemplate(m.getKey(), template);
         }
 
@@ -77,5 +81,15 @@ public class TemplateManager
     public boolean get_st_error()
     {
         return st_error_;
+    }
+
+    public void set_current_template_stgroup(TemplateSTGroup template_stgroup)
+    {
+        current_template_stgroup_ = template_stgroup;
+    }
+
+    public TemplateSTGroup get_current_template_stgroup()
+    {
+        return current_template_stgroup_;
     }
 }

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
@@ -14,8 +14,6 @@
 
 package com.eprosima.idl.generator.manager;
 
-import com.eprosima.idl.generator.manager.TemplateGroup;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.HashMap;
@@ -88,8 +86,13 @@ public class TemplateManager
         current_template_stgroup_ = template_stgroup;
     }
 
-    public TemplateSTGroup get_current_template_stgroup()
+    public boolean is_enabled_custom_property_in_current_group(String custom_property)
     {
-        return current_template_stgroup_;
+        if (null != current_template_stgroup_)
+        {
+            return current_template_stgroup_.is_enabled_custom_property(custom_property);
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateManager.java
@@ -15,8 +15,6 @@
 package com.eprosima.idl.generator.manager;
 
 import com.eprosima.idl.generator.manager.TemplateGroup;
-import com.eprosima.idl.parser.typecode.TypeCode;
-import com.eprosima.idl.context.Context;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -34,23 +32,6 @@ public class TemplateManager
     private Map<String, STGroup> m_groups = new HashMap<String, STGroup>();
 
     private boolean st_error_ = false;
-
-    public TemplateManager(String stackTemplateNames, Context ctx, boolean generate_typesc)
-    {
-        // Load IDL types for stringtemplates
-        TypeCode.idltypesgr = new STGroupFile("com/eprosima/idl/templates/idlTypes.stg", '$', '$');
-        if (generate_typesc)
-        {
-            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/TypesCInterface.stg", '$', '$');
-        }
-        else
-        {
-            TypeCode.cpptypesgr = new STGroupFile("com/eprosima/idl/templates/Types.stg", '$', '$');
-        }
-        TypeCode.ctypesgr = new STGroupFile("com/eprosima/idl/templates/CTypes.stg", '$', '$');
-        TypeCode.javatypesgr = new STGroupFile("com/eprosima/idl/templates/JavaTypes.stg", '$', '$');
-        TypeCode.ctx = ctx;
-    }
 
     public void addGroup(String groupname)
     {

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateST.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateST.java
@@ -1,0 +1,39 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.idl.generator.manager;
+
+import org.stringtemplate.v4.*;
+
+public class TemplateST
+{
+    public TemplateST(TemplateSTGroup parent_group, String template_name)
+    {
+        parent_group_ = parent_group;
+        st_ = parent_group_.get_stgroup().getInstanceOf(template_name);
+    }
+
+    public ST get_st()
+    {
+        return st_;
+    }
+
+    public TemplateSTGroup get_template_stgroup()
+    {
+        return parent_group_;
+    }
+
+    private ST st_ = null;
+    private TemplateSTGroup parent_group_ = null;
+};

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateSTGroup.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateSTGroup.java
@@ -1,0 +1,57 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.idl.generator.manager;
+
+import org.stringtemplate.v4.*;
+
+public class TemplateSTGroup
+{
+    public TemplateSTGroup(String groupname)
+    {
+        st_group_ = new STGroupFile(groupname, '$', '$');
+    }
+
+    public TemplateSTGroup(String groupname, String text)
+    {
+        st_group_ = new STGroupString(groupname, text, '$', '$');
+    }
+
+    public STGroup get_stgroup()
+    {
+        return st_group_;
+    }
+
+    /*!
+     * @brief Returns if the current `Context` scope will be remove from the scoped name of types (returned by
+     * `getScopedname()`).
+     */
+    public boolean is_enabled_using_explicitly_modules()
+    {
+        return using_explicitly_modules_;
+    }
+
+    /*!
+     * @brief Enable removing the current `Context` scope from the scoped name of types (returned by `getScopedname()`).
+     */
+    public void enable_using_explicitly_modules()
+    {
+        using_explicitly_modules_ = true;
+    }
+
+    private STGroup st_group_ = null;
+
+    //! If set, the scoped name of types (returned by `getScopedname()`) will remove the current `Context` scope.
+    private boolean using_explicitly_modules_ = false;
+};

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateSTGroup.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateSTGroup.java
@@ -15,6 +15,7 @@
 package com.eprosima.idl.generator.manager;
 
 import org.stringtemplate.v4.*;
+import java.util.ArrayList;
 
 public class TemplateSTGroup
 {
@@ -34,24 +35,23 @@ public class TemplateSTGroup
     }
 
     /*!
-     * @brief Returns if the current `Context` scope will be remove from the scoped name of types (returned by
-     * `getScopedname()`).
+     * @brief Checks a custom property was added in this template group.
      */
-    public boolean is_enabled_using_explicitly_modules()
+    public boolean is_enabled_custom_property(String custom_property)
     {
-        return using_explicitly_modules_;
+        return custom_properties.contains(custom_property);
     }
 
     /*!
-     * @brief Enable removing the current `Context` scope from the scoped name of types (returned by `getScopedname()`).
+     * @brief Enables a custom property.
      */
-    public void enable_using_explicitly_modules()
+    public void enable_custom_property(String custom_property)
     {
-        using_explicitly_modules_ = true;
+        custom_properties.add(custom_property);
     }
 
     private STGroup st_group_ = null;
 
-    //! If set, the scoped name of types (returned by `getScopedname()`) will remove the current `Context` scope.
-    private boolean using_explicitly_modules_ = false;
+    //! List of custom properties added by the user.
+    ArrayList<String> custom_properties = new ArrayList<String>();
 };

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -35,24 +35,38 @@ public class TemplateUtil
             return type;
     }
 
-    public static void setUnionDefaultLabel(ArrayList<Definition> defs, UnionTypeCode union_type, String scopeFile, int line)
+    /*!
+     * This function tries to find a default discriminator value for the union following the guidelines extracted from
+     * the standard.
+     *
+     * \b 6.14.2 Mapping for Union Types \b
+     * "If there is a default case specified, the union is initialized to this default case.
+     * In case the union has an implicit default member it is initialized to that case.
+     * In all other cases it is initialized to the first discriminant value specified in IDL"
+     */
+    public static void find_and_set_default_discriminator_value(ArrayList<Definition> defs, UnionTypeCode union_type)
     {
-        TypeCode dist_type = union_type.getDiscriminator().getTypecode();
         List<Member> members = union_type.getMembers();
+        TypeCode disc_type = union_type.getDiscriminator().getTypecode();
 
-        if(dist_type != null && union_type.getDefaultMember() != null)
+        if (Kind.KIND_ALIAS == disc_type.getKind())
         {
-            if(dist_type.getKind() == Kind.KIND_OCTET ||
-                    dist_type.getKind() == Kind.KIND_INT8 ||
-                    dist_type.getKind() == Kind.KIND_SHORT ||
-                    dist_type.getKind() == Kind.KIND_LONG ||
-                    dist_type.getKind() == Kind.KIND_LONGLONG ||
-                    dist_type.getKind() == Kind.KIND_UINT8 ||
-                    dist_type.getKind() == Kind.KIND_USHORT ||
-                    dist_type.getKind() == Kind.KIND_ULONG ||
-                    dist_type.getKind() == Kind.KIND_ULONGLONG ||
-                    dist_type.getKind() == Kind.KIND_CHAR ||
-                    dist_type.getKind() == Kind.KIND_WCHAR)
+            disc_type = ((AliasTypeCode)disc_type).getContentTypeCode();
+        }
+
+        if(disc_type != null)
+        {
+            if(disc_type.getKind() == Kind.KIND_OCTET ||
+                    disc_type.getKind() == Kind.KIND_INT8 ||
+                    disc_type.getKind() == Kind.KIND_SHORT ||
+                    disc_type.getKind() == Kind.KIND_LONG ||
+                    disc_type.getKind() == Kind.KIND_LONGLONG ||
+                    disc_type.getKind() == Kind.KIND_UINT8 ||
+                    disc_type.getKind() == Kind.KIND_USHORT ||
+                    disc_type.getKind() == Kind.KIND_ULONG ||
+                    disc_type.getKind() == Kind.KIND_ULONGLONG ||
+                    disc_type.getKind() == Kind.KIND_CHAR ||
+                    disc_type.getKind() == Kind.KIND_WCHAR)
             {
                 long dvalue = -1;
                 boolean found = true;
@@ -79,15 +93,17 @@ public class TemplateUtil
                                 catch(NumberFormatException nfe)
                                 {
                                     // It could be a const
-                                    for (Definition def : defs)
+                                    if (null != defs)
                                     {
-                                        if (def.isIsConstDeclaration())
+                                        for (Definition def : defs)
                                         {
-                                            ConstDeclaration decl = (ConstDeclaration)def;
-                                            if (decl.getName().equals(label))
+                                            if (def.isIsConstDeclaration())
                                             {
-                                                value = Long.decode(decl.getValue());
-                                                //System.out.println("Label " + label + " has value " + value);
+                                                ConstDeclaration decl = (ConstDeclaration)def;
+                                                if (decl.getName().equals(label))
+                                                {
+                                                    value = Long.decode(decl.getValue());
+                                                }
                                             }
                                         }
                                     }
@@ -109,9 +125,9 @@ public class TemplateUtil
                 union_type.setDefaultvalue(Long.toString(dvalue));
                 union_type.setJavaDefaultvalue(Long.toString(dvalue));
             }
-            else if(dist_type.getKind() == Kind.KIND_BOOLEAN)
+            else if(disc_type.getKind() == Kind.KIND_BOOLEAN)
             {
-                if(members.size() == 1 && ((UnionMember)members.get(0)).getLabels().size() == 1)
+                if(1 == members.size() && 1 == ((UnionMember)members.get(0)).getLabels().size())
                 {
                     if(((UnionMember)members.get(0)).getLabels().get(0).equals("true"))
                     {
@@ -125,23 +141,24 @@ public class TemplateUtil
                     }
                     else
                     {
-                        //TODO
-                        //throw new ParseException(((UnionMember)members.get(0)).getLabels().get(0), "is not a valid label for a boolean discriminator.");
                         throw new ParseException(null, "is not a valid label for a boolean discriminator.");
                     }
                 }
+                else if(2 == members.size() && 1 == ((UnionMember)members.get(0)).getLabels().size() &&
+                        1 == ((UnionMember)members.get(1)).getLabels().size())
+                {
+
+                    union_type.setDefaultvalue(((UnionMember)members.get(0)).getLabels().get(0));
+                    union_type.setJavaDefaultvalue(((UnionMember)members.get(0)).getLabels().get(0));
+                }
                 else
                 {
-                    if(members.size() > 2)
-                        throw new ParseException(null, "boolean switch cannot have more than two elements.");
-
-                    union_type.setDefaultvalue("false");
-                    union_type.setJavaDefaultvalue("false");
+                    throw new ParseException(null, "boolean switch is malformed.");
                 }
             }
-            else if(dist_type.getKind() == Kind.KIND_ENUM)
+            else if(disc_type.getKind() == Kind.KIND_ENUM)
             {
-                EnumTypeCode enume = (EnumTypeCode)dist_type;
+                EnumTypeCode enume = (EnumTypeCode)disc_type;
                 List<Member> list = new ArrayList<Member>(members);
                 List<Member> enum_members = new ArrayList<Member>();
                 enum_members.addAll(enume.getMembers());
@@ -170,8 +187,11 @@ public class TemplateUtil
                     union_type.setDefaultvalue(enume.getScopedname() + "::" + enum_members.get(0).getName());
                     union_type.setJavaDefaultvalue(enume.javapackage + enume.getJavaScopedname() + "." + enum_members.get(0).getName());
                 }
-                else
-                    throw new ParseException(null, "All enumeration elements are used in the union");
+                else if (0 < members.size() && 0 < ((UnionMember)members.get(0)).getLabels().size())
+                {
+                    union_type.setDefaultvalue(((UnionMember)members.get(0)).getLabels().get(0));
+                    union_type.setJavaDefaultvalue(((UnionMember)members.get(0)).getLabels().get(0));
+                }
             }
             else
             {
@@ -180,14 +200,13 @@ public class TemplateUtil
         }
     }
 
-    public static String checkUnionLabel(TypeCode dist_type, String label, String scopeFile, int line)
+    public static String checkUnionLabel(TypeCode disc_type, String label)
     {
-        // TODO Faltan tipos: short, unsigneds...
-        if(dist_type != null)
+        if(disc_type != null)
         {
-            if(dist_type.getKind() == Kind.KIND_ENUM)
+            if(disc_type.getKind() == Kind.KIND_ENUM)
             {
-                EnumTypeCode enume = (EnumTypeCode)dist_type;
+                EnumTypeCode enume = (EnumTypeCode)disc_type;
 
                 if(enume.getScope() != null)
                 {
@@ -195,8 +214,6 @@ public class TemplateUtil
                     {
                         if(!label.startsWith(enume.getScope()))
                         {
-                            //TODO
-                            //throw new ParseException(label,  "was not declared previously");
                             throw new ParseException(null,  "was not declared previously");
                         }
                         else
@@ -209,10 +226,23 @@ public class TemplateUtil
                 {
                     if(label.contains("::"))
                     {
-                        //TODO
-                        //throw new ParseException(label, "was not declared previously");
                         throw new ParseException(null, "was not declared previously");
                     }
+                }
+
+                boolean found = false;
+                for(Member member : enume.getMembers())
+                {
+                    if (label.equals(member.getName()))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    throw new ParseException(null, "Invalid enumerator label");
                 }
             }
         }

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -37,7 +37,7 @@ public class TemplateUtil
 
     public static void setUnionDefaultLabel(ArrayList<Definition> defs, UnionTypeCode union_type, String scopeFile, int line)
     {
-        TypeCode dist_type = union_type.getDiscriminator();
+        TypeCode dist_type = union_type.getDiscriminator().getTypecode();
         List<Member> members = union_type.getMembers();
 
         if(dist_type != null && union_type.getDefaultMember() != null)

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -167,7 +167,7 @@ public class TemplateUtil
 
                 if(enum_members.size() > 0)
                 {
-                    union_type.setDefaultvalue(enume.getScope() + "::" + enum_members.get(0).getName());
+                    union_type.setDefaultvalue(enume.getScopedname() + "::" + enum_members.get(0).getName());
                     union_type.setJavaDefaultvalue(enume.javapackage + enume.getJavaScopedname() + "." + enum_members.get(0).getName());
                 }
                 else

--- a/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
@@ -29,18 +29,33 @@ public class Annotation
     public static final String empty_str = "";
     public static final String any_str = "*";
 
+    public static final String ami_str = "ami";
+
+    //{{{ @autoid
     public static final String autoid_str = "autoid";
     public static final String autoid_enum_str = "AutoidKind";
     public static final String autoid_sequential_str = "SEQUENTIAL";
     public static final String autoid_sequential_value_str = "0";
     public static final String autoid_hash_str = "HASH";
     public static final String autoid_hash_value_str = "1";
+    //}}}
 
-    public static final String hashid_str = "hashid";
-    public static final String id_str = "id";
-    public static final String key_str = "key";
-    public static final String eprosima_key_str = "Key";
+    public static final String bit_bound_str = "bit_bound";
 
+    //{{{ @data_representation
+    public static final String data_representation_mask_str = "DataRepresentationMask";
+    public static final String xcdr1_bitflag_str = "XCDR1";
+    public static final String xml_bitflag_str = "XML";
+    public static final String xcdr2_bitflag_str = "XCDR2";
+    public static final String data_representation_str = "data_representation";
+    public static final String allowed_kinds_str = "allowed_kinds";
+    //}}}
+
+    public static final String default_str = "default";
+    public static final String default_literal_str = "default_literal";
+    public static final String default_nested_str = "default_nested";
+
+    //{{{ @extensibility
     public static final String extensibility_str = "extensibility";
     public static final String extensibility_enum_str = "ExtensibilityKind";
     public static final String final_str = "final";
@@ -52,24 +67,50 @@ public class Annotation
     public static final String ex_appendable_val = "1";
     public static final String ex_mutable_str = "MUTABLE";
     public static final String ex_mutable_val = "2";
+    //}}}
 
-    public static final String value_str = "value";
-
-    public static final String optional_str = "optional";
     public static final String external_str = "external";
-    public static final String position_str = "position";
-    public static final String must_understand_str = "must_understand";
-    public static final String default_literal_str = "default_literal";
-    public static final String default_str = "default";
-    public static final String range_str = "range";
-    public static final String min_str = "min";
-    public static final String max_str = "max";
-    public static final String unit_str = "unit";
-    public static final String bit_bound_str = "bit_bound";
-    public static final String nested_str = "nested";
-    public static final String default_nested_str = "default_nested";
+    public static final String hashid_str = "hashid";
+    public static final String id_str = "id";
     public static final String ignore_literal_names_str = "ignore_literal_names";
 
+    ///{{{ @key
+    public static final String key_str = "key";
+    public static final String eprosima_key_str = "Key";
+    //}}}
+
+    public static final String max_str = "max";
+    public static final String min_str = "min";
+    public static final String must_understand_str = "must_understand";
+    public static final String nested_str = "nested";
+    public static final String non_serialized_str = "non_serialized";
+    public static final String oneway_str = "oneway";
+    public static final String optional_str = "optional";
+    public static final String position_str = "position";
+    public static final String range_str = "range";
+
+    //{{{ @service
+    public static final String service_str = "service";
+    public static final String platform_str = "platform";
+    //}}}
+
+    //{{{ @topic
+    public static final String topic_str = "topic";
+    public static final String name_str = "name";
+    //}}}
+
+    //{{{ @try_construct
+    public static final String try_construct_str = "try_construct";
+    public static final String try_construct_enum_str = "TryConstructFailAction";
+    public static final String try_construct_discard_str = "DISCARD";
+    public static final String try_construct_use_default_str = "USE_DEFAULT";
+    public static final String try_construct_trim_str = "TRIM";
+    //}}}
+
+    public static final String unit_str = "unit";
+    public static final String value_str = "value";
+
+    //{{{ @verbatim
     public static final String verbatim_str = "verbatim";
     public static final String placement_enum_str = "PlacementKind";
     public static final String begin_file_str = "BEGIN_FILE";
@@ -81,27 +122,7 @@ public class Annotation
     public static final String language_str = "language";
     public static final String placement_str = "placement";
     public static final String text_str = "text";
-
-    public static final String service_str = "service";
-    public static final String platform_str = "platform";
-    public static final String oneway_str = "oneway";
-    public static final String ami_str = "ami";
-
-    public static final String non_serialized_str = "non_serialized";
-    public static final String data_representation_mask_str = "DataRepresentationMask";
-    public static final String xcdr1_bitflag_str = "XCDR1";
-    public static final String xml_bitflag_str = "XML";
-    public static final String xcdr2_bitflag_str = "XCDR2";
-    public static final String data_representation_str = "data_representation";
-    public static final String allowed_kinds_str = "allowed_kinds";
-    public static final String topic_str = "topic";
-    public static final String name_str = "name";
-
-    public static final String try_construct_str = "try_construct";
-    public static final String try_construct_enum_str = "TryConstructFailAction";
-    public static final String try_construct_discard_str = "DISCARD";
-    public static final String try_construct_use_default_str = "USE_DEFAULT";
-    public static final String try_construct_trim_str = "TRIM";
+    //}}}
 
     public Annotation(AnnotationDeclaration declaration)
     {
@@ -259,38 +280,38 @@ public class Annotation
 
     public boolean isIsBuiltin()
     {
-        if (getName().equals(Annotation.id_str) ||
+        if (getName().equals(Annotation.ami_str) ||
+            getName().equals(Annotation.appendable_str) ||
             getName().equals(Annotation.autoid_str) ||
+            getName().equals(Annotation.bit_bound_str) ||
+            getName().equals(Annotation.data_representation_str) ||
+            getName().equals(Annotation.default_str) ||
+            getName().equals(Annotation.default_literal_str) ||
+            getName().equals(Annotation.default_nested_str) ||
+            getName().equals(Annotation.eprosima_key_str) ||
+            getName().equals(Annotation.extensibility_str) ||
+            getName().equals(Annotation.external_str) ||
+            getName().equals(Annotation.final_str) ||
+            getName().equals(Annotation.hashid_str) ||
+            getName().equals(Annotation.id_str) ||
+            getName().equals(Annotation.ignore_literal_names_str) ||
+            getName().equals(Annotation.key_str) ||
+            getName().equals(Annotation.max_str) ||
+            getName().equals(Annotation.min_str) ||
+            getName().equals(Annotation.must_understand_str) ||
+            getName().equals(Annotation.mutable_str) ||
+            getName().equals(Annotation.nested_str) ||
+            getName().equals(Annotation.non_serialized_str) ||
+            getName().equals(Annotation.oneway_str) ||
             getName().equals(Annotation.optional_str) ||
             getName().equals(Annotation.position_str) ||
-            getName().equals(Annotation.value_str) ||
-            getName().equals(Annotation.extensibility_str) ||
-            getName().equals(Annotation.final_str) ||
-            getName().equals(Annotation.appendable_str) ||
-            getName().equals(Annotation.mutable_str) ||
-            getName().equals(Annotation.key_str) ||
-            getName().equals(Annotation.eprosima_key_str) ||
-            getName().equals(Annotation.must_understand_str) ||
-            getName().equals(Annotation.default_literal_str) ||
-            getName().equals(Annotation.default_str) ||
             getName().equals(Annotation.range_str) ||
-            getName().equals(Annotation.min_str) ||
-            getName().equals(Annotation.max_str) ||
-            getName().equals(Annotation.unit_str) ||
-            getName().equals(Annotation.bit_bound_str) ||
-            getName().equals(Annotation.external_str) ||
-            getName().equals(Annotation.nested_str) ||
-            getName().equals(Annotation.verbatim_str) ||
             getName().equals(Annotation.service_str) ||
-            getName().equals(Annotation.oneway_str) ||
-            getName().equals(Annotation.ami_str) ||
-            getName().equals(Annotation.hashid_str) ||
-            getName().equals(Annotation.default_nested_str) ||
-            getName().equals(Annotation.ignore_literal_names_str) ||
+            getName().equals(Annotation.topic_str) ||
             getName().equals(Annotation.try_construct_str) ||
-            getName().equals(Annotation.non_serialized_str) ||
-            getName().equals(Annotation.data_representation_str) ||
-            getName().equals(Annotation.topic_str))
+            getName().equals(Annotation.unit_str) ||
+            getName().equals(Annotation.value_str) ||
+            getName().equals(Annotation.verbatim_str))
         {
             return true;
         }

--- a/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
@@ -18,17 +18,28 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.typecode.TypeCode;
+
 public class Annotation
 {
+    public static final String null_default_value = "0";
+    public static final String true_str = "true";
+    public static final String capitalized_true_str = "TRUE";
+    public static final String empty_str = "";
+    public static final String any_str = "*";
+
     public static final String autoid_str = "autoid";
     public static final String autoid_enum_str = "AutoidKind";
     public static final String autoid_sequential_str = "SEQUENTIAL";
     public static final String autoid_sequential_value_str = "0";
     public static final String autoid_hash_str = "HASH";
+    public static final String autoid_hash_value_str = "1";
 
     public static final String hashid_str = "hashid";
     public static final String id_str = "id";
     public static final String key_str = "key";
+    public static final String eprosima_key_str = "Key";
 
     public static final String extensibility_str = "extensibility";
     public static final String extensibility_enum_str = "ExtensibilityKind";
@@ -46,6 +57,51 @@ public class Annotation
 
     public static final String optional_str = "optional";
     public static final String external_str = "external";
+    public static final String position_str = "position";
+    public static final String must_understand_str = "must_understand";
+    public static final String default_literal_str = "default_literal";
+    public static final String default_str = "default";
+    public static final String range_str = "range";
+    public static final String min_str = "min";
+    public static final String max_str = "max";
+    public static final String unit_str = "unit";
+    public static final String bit_bound_str = "bit_bound";
+    public static final String nested_str = "nested";
+    public static final String default_nested_str = "default_nested";
+    public static final String ignore_literal_names_str = "ignore_literal_names";
+
+    public static final String verbatim_str = "verbatim";
+    public static final String placement_enum_str = "PlacementKind";
+    public static final String begin_file_str = "BEGIN_FILE";
+    public static final String before_declaration_str = "BEFORE_DECLARATION";
+    public static final String begin_declaration_str = "BEGIN_DECLARATION";
+    public static final String end_declaration_str = "END_DECLARATION";
+    public static final String after_declaration_str = "AFTER_DECLARATION";
+    public static final String end_file_str = "END_FILE";
+    public static final String language_str = "language";
+    public static final String placement_str = "placement";
+    public static final String text_str = "text";
+
+    public static final String service_str = "service";
+    public static final String platform_str = "platform";
+    public static final String oneway_str = "oneway";
+    public static final String ami_str = "ami";
+
+    public static final String non_serialized_str = "non_serialized";
+    public static final String data_representation_mask_str = "DataRepresentationMask";
+    public static final String xcdr1_bitflag_str = "XCDR1";
+    public static final String xml_bitflag_str = "XML";
+    public static final String xcdr2_bitflag_str = "XCDR2";
+    public static final String data_representation_str = "data_representation";
+    public static final String allowed_kinds_str = "allowed_kinds";
+    public static final String topic_str = "topic";
+    public static final String name_str = "name";
+
+    public static final String try_construct_str = "try_construct";
+    public static final String try_construct_enum_str = "TryConstructFailAction";
+    public static final String try_construct_discard_str = "DISCARD";
+    public static final String try_construct_use_default_str = "USE_DEFAULT";
+    public static final String try_construct_trim_str = "TRIM";
 
     public Annotation(AnnotationDeclaration declaration)
     {
@@ -69,10 +125,57 @@ public class Annotation
         return null;
     }
 
+    /*!
+     * @brief Returns the full scoped name of the type, unless the developer uses
+     * `TemplateSTGroup.enable_using_explicitly_modules()`, by removing from the full scoped name the current
+     * `Context` scope.
+     */
+    public String getScopedname() throws RuntimeGenerationException
+    {
+        String scoped_name = getFullScopedname();
+
+        if (!com.eprosima.idl.parser.typecode.TypeCode.ctx.is_enabled_custom_property_in_current_group(com.eprosima.idl.parser.typecode.TypeCode.ctx.using_explicitly_modules_custom_property))
+        {
+            return scoped_name;
+        }
+
+        String current_scope = com.eprosima.idl.parser.typecode.TypeCode.ctx.getScope();
+
+        if(current_scope.isEmpty() || !scoped_name.startsWith(current_scope + "::"))
+        {
+            return scoped_name;
+        }
+
+        return scoped_name.replace(current_scope + "::", "");
+    }
+
+    /*!
+     * @brief Return the scoped name of the type.
+     */
+    public String getFullScopedname() throws RuntimeGenerationException
+    {
+        if(m_declaration == null)
+        {
+            throw new RuntimeGenerationException("Annotation declaration not initialized");
+        }
+        return m_declaration.getScopedname();
+    }
+
+    public String getROS2Scopedname() throws RuntimeGenerationException
+    {
+        if(m_declaration == null)
+        {
+            throw new RuntimeGenerationException("Annotation declaration not initialized");
+        }
+        return m_declaration.getROS2Scopedname();
+    }
+
     public boolean addValue(String value)
     {
         if(m_members.size() != 1)
+        {
             return false;
+        }
 
         ((AnnotationMember)m_members.values().toArray()[0]).setValue(value);
 
@@ -86,16 +189,25 @@ public class Annotation
         if(member != null)
         {
             member.setValue(value);
+            // Check that in case of an Enum the set value is in the enumeration.
+            // ParseException is thrown otherwise.
+            member.getEnumStringValue();
         }
         else
+        {
             return false;
+        }
 
         return true;
     }
 
-    public String getValue()
+    public String getValue() throws RuntimeGenerationException
     {
-        if(m_members.size() != 1) return null;
+        if(m_members.size() != 1)
+        {
+            throw new RuntimeGenerationException("Error in annotation " + getName() +
+                    ": accessing value of a multiple parameter exception");
+        }
 
         return ((AnnotationMember)m_members.values().toArray()[0]).getValue();
     }
@@ -113,6 +225,81 @@ public class Annotation
     public Collection<AnnotationMember> getValueList()
     {
         return m_members.values();
+    }
+
+    public boolean isIsVerbatim()
+    {
+        return getName().equals(Annotation.verbatim_str);
+    }
+
+    public boolean isIsUnit()
+    {
+        return getName().equals(Annotation.unit_str);
+    }
+
+    public boolean isIsMax()
+    {
+        return getName().equals(Annotation.max_str);
+    }
+
+    public boolean isIsMin()
+    {
+        return getName().equals(Annotation.min_str);
+    }
+
+    public boolean isIsRange()
+    {
+        return getName().equals(Annotation.range_str);
+    }
+
+    public boolean isIsHashId()
+    {
+        return getName().equals(Annotation.hashid_str);
+    }
+
+    public boolean isIsBuiltin()
+    {
+        if (getName().equals(Annotation.id_str) ||
+            getName().equals(Annotation.autoid_str) ||
+            getName().equals(Annotation.optional_str) ||
+            getName().equals(Annotation.position_str) ||
+            getName().equals(Annotation.value_str) ||
+            getName().equals(Annotation.extensibility_str) ||
+            getName().equals(Annotation.final_str) ||
+            getName().equals(Annotation.appendable_str) ||
+            getName().equals(Annotation.mutable_str) ||
+            getName().equals(Annotation.key_str) ||
+            getName().equals(Annotation.eprosima_key_str) ||
+            getName().equals(Annotation.must_understand_str) ||
+            getName().equals(Annotation.default_literal_str) ||
+            getName().equals(Annotation.default_str) ||
+            getName().equals(Annotation.range_str) ||
+            getName().equals(Annotation.min_str) ||
+            getName().equals(Annotation.max_str) ||
+            getName().equals(Annotation.unit_str) ||
+            getName().equals(Annotation.bit_bound_str) ||
+            getName().equals(Annotation.external_str) ||
+            getName().equals(Annotation.nested_str) ||
+            getName().equals(Annotation.verbatim_str) ||
+            getName().equals(Annotation.service_str) ||
+            getName().equals(Annotation.oneway_str) ||
+            getName().equals(Annotation.ami_str) ||
+            getName().equals(Annotation.hashid_str) ||
+            getName().equals(Annotation.default_nested_str) ||
+            getName().equals(Annotation.ignore_literal_names_str) ||
+            getName().equals(Annotation.try_construct_str) ||
+            getName().equals(Annotation.non_serialized_str) ||
+            getName().equals(Annotation.data_representation_str) ||
+            getName().equals(Annotation.topic_str))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public int getValuesSize()
+    {
+        return m_members.size();
     }
 
     private HashMap<String, AnnotationMember> m_members = null;

--- a/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
@@ -44,6 +44,9 @@ public class Annotation
 
     public static final String value_str = "value";
 
+    public static final String optional_str = "optional";
+    public static final String external_str = "external";
+
     public Annotation(AnnotationDeclaration declaration)
     {
         m_declaration = declaration;

--- a/src/main/java/com/eprosima/idl/parser/tree/AnnotationDeclaration.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/AnnotationDeclaration.java
@@ -42,6 +42,11 @@ public class AnnotationDeclaration extends TreeNode implements Definition
         return new ArrayList<AnnotationMember>(m_members.values());
     }
 
+    public int getMembersSize()
+    {
+        return m_members.values().size();
+    }
+
     public void addMembers(AnnotationDeclaration annotation)
     {
         m_members.putAll(annotation.m_members);
@@ -49,6 +54,9 @@ public class AnnotationDeclaration extends TreeNode implements Definition
 
     public boolean addMember(AnnotationMember member)
     {
+        // Check that in case of an Enum the given value is in the enumeration.
+        // ParseException is thrown otherwise.
+        member.getEnumStringValue();
         if(!m_members.containsKey(member.getName()))
         {
             m_members.put(member.getName(), member);

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -51,7 +51,9 @@ public class TreeNode implements Notebook
     public String getScopedname()
     {
         if(m_scope == null || m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope + "::" + m_name;
     }
@@ -59,7 +61,9 @@ public class TreeNode implements Notebook
     public String getROS2Scopedname()
     {
         if(m_scope == null || m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope + "::dds_::" + m_name + "_";
     }
@@ -67,7 +71,9 @@ public class TreeNode implements Notebook
     public String getCScopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope.replace("::", "_") + "_" + m_name;
     }
@@ -75,7 +81,9 @@ public class TreeNode implements Notebook
     public String getJavaScopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope.replace("::", ".") + "." + m_name;
     }
@@ -94,9 +102,13 @@ public class TreeNode implements Notebook
         String ret = null;
 
         if(m_scope == null || m_scope.isEmpty())
+        {
             ret = m_name;
+        }
         else
+        {
             ret = m_scope + "::" + m_name;
+        }
 
         return ret.replaceAll("::", "_");
     }
@@ -110,7 +122,9 @@ public class TreeNode implements Notebook
     public void addAnnotation(Context ctx, Annotation annotation)
     {
         if(annotation != null)
+        {
             m_annotations.put(annotation.getName(), annotation);
+        }
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -178,6 +178,16 @@ public class AliasTypeCode extends ContainerTypeCode
         return m_scope + "::dds_::" + m_name + "_";
     }
 
+    public String getCScopedname()
+    {
+        if(m_scope.isEmpty())
+        {
+            return m_name;
+        }
+
+        return m_scope.replace("::", "_") + "_" + m_name;
+    }
+
     public String getScope()
     {
         return m_scope;

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -297,6 +297,12 @@ public class AliasTypeCode extends ContainerTypeCode
         return super.getContentTypeCode().isIsBitmaskType();
     }
 
+    @Override
+    public boolean isIsEnumType()
+    {
+        return super.getContentTypeCode().isIsEnumType();
+    }
+
     public boolean isIsType_10()
     {
         return true;

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -260,7 +260,7 @@ public class AliasTypeCode extends ContainerTypeCode
         return super.getContentTypeCode().getInitialValue();
     }
 
-    /*** Functions to know the type in string templates ***/
+    //{{{ Functions to know the type in string templates
     @Override
     public boolean isIsType_d()
     {
@@ -325,9 +325,9 @@ public class AliasTypeCode extends ContainerTypeCode
         return "EK_MINIMAL";
     }
 
-    /*** End of functions to know the type in string templates ***/
+    //}}}
 
-    /*** Functions that alias has to export because some typecodes have them*/
+    //{{{ Functions that alias has to export because some typecodes have them
     public String getMaxsize()
     {
         return super.getContentTypeCode().getMaxsize();
@@ -365,7 +365,7 @@ public class AliasTypeCode extends ContainerTypeCode
                 ": trying accessing dimensions for a non-array type");
     }
 
-    public int getFullBitSize()
+    public int getFullBitSize() // Function for alias when enclosed type is a BitsetTypeCode
     {
         int returnedValue = 0;
 
@@ -377,7 +377,31 @@ public class AliasTypeCode extends ContainerTypeCode
         return returnedValue;
     }
 
-    /*** End of functions that alias has to export because some typecodes have them*/
+    public TypeCode getInheritance() // Function for alias when enclosed type is a StructTypeCode
+    {
+        TypeCode returnedValue = null;
+
+        if (getContentTypeCode() instanceof StructTypeCode)
+        {
+            returnedValue = ((StructTypeCode)getContentTypeCode()).getInheritance();
+        }
+
+        return returnedValue;
+    }
+
+    public List<Member> getMembers() // Function for alias when enclosed type is a StructTypeCode
+    {
+        List<Member> returnedValue = null;
+
+        if (getContentTypeCode() instanceof StructTypeCode)
+        {
+            returnedValue = ((StructTypeCode)getContentTypeCode()).getMembers();
+        }
+
+        return returnedValue;
+    }
+
+    //}}}
 
     private String m_name = null;
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -130,11 +130,16 @@ public class AliasTypeCode extends ContainerTypeCode
         return m_name;
     }
 
+    /*!
+     * @brief Returns the full scoped name of the type, unless the developer uses
+     * `TemplateSTGroup.enable_custom_proeprty("using_explicitly_modules")`, by removing from the full scoped name the
+     * current `Context` scope.
+     */
     public String getScopedname()
     {
         String scoped_name = getFullScopedname();
 
-        if (!ctx.get_template_manager().get_current_template_stgroup().is_enabled_using_explicitly_modules())
+        if (!ctx.is_enabled_custom_property_in_current_group(ctx.using_explicitly_modules_custom_property))
         {
             return scoped_name;
         }

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -132,7 +132,29 @@ public class AliasTypeCode extends ContainerTypeCode
 
     public String getScopedname()
     {
-        if (m_scope.isEmpty())
+        String scoped_name = getFullScopedname();
+
+        if (!ctx.get_template_manager().get_current_template_stgroup().is_enabled_using_explicitly_modules())
+        {
+            return scoped_name;
+        }
+
+        String current_scope = ctx.getScope();
+
+        if(current_scope.isEmpty() || !scoped_name.startsWith(current_scope + "::"))
+        {
+            return scoped_name;
+        }
+
+        return scoped_name.replace(current_scope + "::", "");
+    }
+
+    /*!
+     * @brief Return the scoped name of the type.
+     */
+    public String getFullScopedname()
+    {
+        if(m_scope.isEmpty())
         {
             return m_name;
         }

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.util.Pair;
 import java.util.List;
 import org.stringtemplate.v4.ST;
@@ -327,14 +328,31 @@ public class AliasTypeCode extends ContainerTypeCode
         return super.getContentTypeCode().getSize();
     }
 
-    public List<String> getDimensions()
+    public String getEvaluatedMaxsize() throws RuntimeGenerationException
+    {
+        return super.getContentTypeCode().getEvaluatedMaxsize();
+    }
+
+    public List<String> getDimensions() throws RuntimeGenerationException
     {
         if (super.getContentTypeCode() instanceof ArrayTypeCode)
         {
             return ((ArrayTypeCode) super.getContentTypeCode()).getDimensions();
         }
 
-        return null;
+        throw new RuntimeGenerationException("Error in alias " + m_name +
+                ": trying accessing dimensions for a non-array type");
+    }
+
+    public List<String> getEvaluatedDimensions() throws RuntimeGenerationException
+    {
+        if (super.getContentTypeCode() instanceof ArrayTypeCode)
+        {
+            return ((ArrayTypeCode) super.getContentTypeCode()).getEvaluatedDimensions();
+        }
+
+        throw new RuntimeGenerationException("Error in alias " + m_name +
+                ": trying accessing dimensions for a non-array type");
     }
 
     public int getFullBitSize()

--- a/src/main/java/com/eprosima/idl/parser/typecode/ArrayTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/ArrayTypeCode.java
@@ -36,7 +36,15 @@ public class ArrayTypeCode extends ContainerTypeCode
     @Override
     public String getTypeIdentifier()
     {
-        return "TI_PLAIN_ARRAY_SMALL";
+        String type_id = "TI_PLAIN_ARRAY_SMALL";
+        for (int count = 0; count < evaluated_dimensions_.size(); ++count)
+        {
+            if (Integer.parseInt(evaluated_dimensions_.get(count)) >= 256)
+            {
+                return "TI_PLAIN_ARRAY_LARGE";
+            }
+        }
+        return type_id;
     }
 
     @Override
@@ -183,6 +191,11 @@ public class ArrayTypeCode extends ContainerTypeCode
     public List<String> getEvaluatedDimensions()
     {
         return evaluated_dimensions_;
+    }
+
+    public int getEvaluatedDimensionsSize()
+    {
+        return evaluated_dimensions_.size();
     }
 
     public String getSize()

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
@@ -26,7 +26,7 @@ public class BitfieldSpec
         }
         else if (size <= 8)
         {
-            return Kind.KIND_CHAR;
+            return Kind.KIND_OCTET;
         }
         else if (size <= 16)
         {

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitmaskTypeCode.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.context.Context;
 
@@ -133,8 +134,15 @@ public class BitmaskTypeCode extends MemberedTypeCode
         {
             if (bitmask.getAnnotations().get("position") != null)
             {
-                // Position from attribute
-                return addBitmask(bitmask, Integer.parseInt(bitmask.getAnnotations().get("position").getValue()));
+                try
+                {
+                    // Position from attribute
+                    return addBitmask(bitmask, Integer.parseInt(bitmask.getAnnotations().get("position").getValue()));
+                }
+                catch (RuntimeGenerationException ex)
+                {
+                    // Should not be called as @position annotation has only one parameter
+                }
             }
             // Position autoassigned
             return addBitmask(bitmask, m_current_base);
@@ -232,16 +240,23 @@ public class BitmaskTypeCode extends MemberedTypeCode
         super.addAnnotation(ctx, annotation);
         if (annotation.getName().equals("bit_bound"))
         {
-            m_bit_bound = Integer.parseInt(annotation.getValue());
-            // Sanity check
-            Set<String> keys = m_bitmasks.keySet();
-            for (String key : keys) {
-                int position = m_bitmasks.get(key).getPosition();
-                if (position < 0 || position >= m_bit_bound)
-                {
-                    throw new ParseException(null, "Bitmask member "+ key +" out of bounds. Requested position: "
-                    + position + " with @bit_bound value: " + m_bit_bound);
+            try
+            {
+                m_bit_bound = Integer.parseInt(annotation.getValue());
+                // Sanity check
+                Set<String> keys = m_bitmasks.keySet();
+                for (String key : keys) {
+                    int position = m_bitmasks.get(key).getPosition();
+                    if (position < 0 || position >= m_bit_bound)
+                    {
+                        throw new ParseException(null, "Bitmask member "+ key +" out of bounds. Requested position: "
+                        + position + " with @bit_bound value: " + m_bit_bound);
+                    }
                 }
+            }
+            catch (RuntimeGenerationException ex)
+            {
+               // Should not be called as @bit_bound annotation only has one parameter
             }
         }
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitsetTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitsetTypeCode.java
@@ -104,7 +104,12 @@ public class BitsetTypeCode extends MemberedTypeCode implements Inherits
     public boolean addBitfield(
             Bitfield bitfield)
     {
-        if (!m_bitfields.containsKey(bitfield.getName()))
+        if (null == bitfield.getName())
+        {
+            m_current_base += bitfield.getSpec().getBitSize();
+            return true;
+        }
+        if (!m_bitfields.containsKey(bitfield.getName()) )
         {
             m_bitfields.put(bitfield.getName(), bitfield);
             bitfield.setBasePosition(m_current_base);
@@ -161,13 +166,7 @@ public class BitsetTypeCode extends MemberedTypeCode implements Inherits
 
     public int getBitSize()
     {
-        int size = 0;
-
-        for (Bitfield bf : m_bitfields.values())
-        {
-            size += bf.getSpec().getBitSize();
-        }
-        return size;
+        return m_current_base;
     }
 
     public int getFullBitSize()
@@ -179,11 +178,7 @@ public class BitsetTypeCode extends MemberedTypeCode implements Inherits
             size += enclosed_super_type_.getFullBitSize();
         }
 
-        for (Bitfield bf : m_bitfields.values())
-        {
-            size += bf.getSpec().getBitSize();
-        }
-        return size;
+        return m_current_base + size;
     }
 
     private BitsetTypeCode enclosed_super_type_ = null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/CollectionElement.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/CollectionElement.java
@@ -1,0 +1,41 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.idl.parser.typecode;
+
+public class CollectionElement extends MemberAppliedAnnotations
+{
+    public CollectionElement()
+    {
+        super();
+    }
+
+    public CollectionElement(TypeCode typecode)
+    {
+        super();
+        typecode_ = typecode;
+    }
+
+    public TypeCode getTypecode()
+    {
+        return typecode_;
+    }
+
+    public void setTypecode(TypeCode typecode)
+    {
+        typecode_ = typecode;
+    }
+
+    private TypeCode typecode_ = null;
+}

--- a/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
@@ -34,7 +34,7 @@ public abstract class ContainerTypeCode extends TypeCode
 
     public TypeCode getContentTypeCode()
     {
-        return m_contentTypeCode;
+        return collection_element_.getTypecode();
     }
 
     public Definition getContentDefinition()
@@ -44,7 +44,7 @@ public abstract class ContainerTypeCode extends TypeCode
 
     public void setContentTypeCode(TypeCode contentTypeCode)
     {
-        m_contentTypeCode = contentTypeCode;
+        collection_element_.setTypecode(contentTypeCode);
     }
 
     public void setContentDefinition(Definition contentDefinition)
@@ -56,11 +56,11 @@ public abstract class ContainerTypeCode extends TypeCode
     {
         int ret = 1;
 
-        if (m_contentTypeCode.isPrimitive()) {
+        if (collection_element_.getTypecode().isPrimitive()) {
     	    return ret;
     	} else {
-    	    if (m_contentTypeCode instanceof ContainerTypeCode) {
-    		    ret += ((ContainerTypeCode) m_contentTypeCode).getDepth();
+    	    if (collection_element_.getTypecode() instanceof ContainerTypeCode) {
+    		    ret += ((ContainerTypeCode) collection_element_.getTypecode()).getDepth();
     		}
     	}
 
@@ -70,9 +70,9 @@ public abstract class ContainerTypeCode extends TypeCode
     @Override
     public boolean isIsPlain()
     {
-        if (m_contentTypeCode != null)
+        if (collection_element_.getTypecode() != null)
         {
-            return m_contentTypeCode.isIsPlain();
+            return collection_element_.getTypecode().isIsPlain();
         }
         return false;
     }
@@ -80,13 +80,13 @@ public abstract class ContainerTypeCode extends TypeCode
     @Override
     public boolean isIsBounded()
     {
-        if (m_contentTypeCode != null)
+        if (collection_element_.getTypecode() != null)
         {
-            return m_contentTypeCode.isIsBounded();
+            return collection_element_.getTypecode().isIsBounded();
         }
         return false;
     }
 
-    private TypeCode m_contentTypeCode = null;
+    private CollectionElement collection_element_ = new CollectionElement();
     private Definition m_contentDefinition = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
@@ -18,6 +18,8 @@ import com.eprosima.idl.parser.tree.Definition;
 
 public abstract class ContainerTypeCode extends TypeCode
 {
+    public static String default_unbounded_max_size = "0";
+
     protected ContainerTypeCode(int kind)
     {
         super(kind);
@@ -56,13 +58,17 @@ public abstract class ContainerTypeCode extends TypeCode
     {
         int ret = 1;
 
-        if (collection_element_.getTypecode().isPrimitive()) {
-    	    return ret;
-    	} else {
-    	    if (collection_element_.getTypecode() instanceof ContainerTypeCode) {
-    		    ret += ((ContainerTypeCode) collection_element_.getTypecode()).getDepth();
-    		}
-    	}
+        if (collection_element_.getTypecode().isPrimitive())
+        {
+            return ret;
+        }
+        else
+        {
+            if (collection_element_.getTypecode() instanceof ContainerTypeCode)
+            {
+                ret += ((ContainerTypeCode) collection_element_.getTypecode()).getDepth();
+            }
+        }
 
         return ret;
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
@@ -133,5 +133,11 @@ public class EnumTypeCode extends MemberedTypeCode
     {
         return true;
     }
+    
+    public int getBitBound()
+    {
+        // TODO: pending @bit_bound annotation application to enum types
+        return 32;
+    }
 
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
@@ -99,7 +99,7 @@ public class EnumTypeCode extends MemberedTypeCode
     {
         if (getMembers().size() > 0)
         {
-            return (getScope() != null ? getScope() + "::" : "") + getMembers().get(0).getName();
+            return getScopedname() + "::" + getMembers().get(0).getName();
         }
 
         return "";

--- a/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
@@ -96,7 +96,7 @@ public class MapTypeCode extends ContainerTypeCode
     {
         if (m_maxsize == null)
         {
-            return "100";
+            return default_unbounded_max_size;
         }
 
         return m_maxsize;
@@ -154,6 +154,11 @@ public class MapTypeCode extends ContainerTypeCode
             Definition valueDefinition)
     {
         m_valueDefinition = valueDefinition;
+    }
+
+    public boolean isUnbound()
+    {
+        return null == m_maxsize;
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
@@ -37,6 +37,10 @@ public class MapTypeCode extends ContainerTypeCode
     @Override
     public String getTypeIdentifier()
     {
+        if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+        {
+            return "TI_PLAIN_MAP_LARGE";
+        }
         return "TI_PLAIN_MAP_SMALL";
     }
 
@@ -92,6 +96,7 @@ public class MapTypeCode extends ContainerTypeCode
         return st.render();
     }
 
+    @Override
     public String getMaxsize()
     {
         if (m_maxsize == null)
@@ -102,6 +107,7 @@ public class MapTypeCode extends ContainerTypeCode
         return m_maxsize;
     }
 
+    @Override
     public String getEvaluatedMaxsize()
     {
         if (evaluated_maxsize_ == null)

--- a/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MapTypeCode.java
@@ -37,7 +37,7 @@ public class MapTypeCode extends ContainerTypeCode
     @Override
     public String getTypeIdentifier()
     {
-        if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+        if (!isUnbound() && Integer.parseInt(evaluated_maxsize_) >= 256)
         {
             return "TI_PLAIN_MAP_LARGE";
         }
@@ -162,6 +162,10 @@ public class MapTypeCode extends ContainerTypeCode
         m_valueDefinition = valueDefinition;
     }
 
+    /**
+     * This API is to check if this specific collection has a bound set.
+     * It does not check if the complete collection is bounded or not.
+     */
     public boolean isUnbound()
     {
         return null == m_maxsize;
@@ -173,6 +177,10 @@ public class MapTypeCode extends ContainerTypeCode
         return false;
     }
 
+    /**
+     * This API is to check if ultimately the collection element is bounded.
+     * In order to check if this specific collection has bounds, please use isUnbound API.
+     */
     @Override
     public boolean isIsBounded()
     {

--- a/src/main/java/com/eprosima/idl/parser/typecode/Member.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/Member.java
@@ -14,6 +14,9 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.tree.Annotation;
+
 public class Member extends MemberAppliedAnnotations
 {
     public Member()
@@ -121,6 +124,40 @@ public class Member extends MemberAppliedAnnotations
     public int getIndex()
     {
         return index_;
+    }
+
+    public boolean isAnnotationId()
+    {
+        return null != getAnnotations().get(Annotation.id_str);
+    }
+
+    public String getAnnotationIdValue() throws RuntimeGenerationException
+    {
+        Annotation ann = getAnnotations().get(Annotation.id_str);
+        if (ann == null)
+        {
+            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.id_str +
+                    " annotation not found.");
+        }
+
+        return ann.getValue();
+    }
+
+    public boolean isAnnotationHashid()
+    {
+        return null != getAnnotations().get(Annotation.hashid_str);
+    }
+
+    public String getAnnotationHashidValue() throws RuntimeGenerationException
+    {
+        Annotation ann = getAnnotations().get(Annotation.hashid_str);
+        if (ann == null)
+        {
+            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.hashid_str +
+                    " annotation not found.");
+        }
+
+        return ann.getValue();
     }
 
     private String m_name = null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/Member.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/Member.java
@@ -14,27 +14,18 @@
 
 package com.eprosima.idl.parser.typecode;
 
-import com.eprosima.idl.parser.exception.RuntimeGenerationException;
-import com.eprosima.idl.parser.tree.Annotation;
-import com.eprosima.idl.parser.tree.Notebook;
-import com.eprosima.idl.context.Context;
-
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Collection;
-
-public class Member implements Notebook
+public class Member extends MemberAppliedAnnotations
 {
     public Member()
     {
-        m_annotations = new HashMap<String, Annotation>();
+        super();
     }
 
     public Member(TypeCode typecode, String name)
     {
+        super();
         m_typecode = typecode;
         m_name = name;
-        m_annotations = new HashMap<String, Annotation>();
     }
 
     public String getName()
@@ -73,140 +64,6 @@ public class Member implements Notebook
          m_typecode = typecode;
     }
 
-    @Override
-    public void addAnnotation(Context ctx, Annotation annotation)
-    {
-        if(annotation != null)
-        {
-            m_annotations.put(annotation.getName(), annotation);
-        }
-    }
-
-    @Override
-    public Map<String, Annotation> getAnnotations()
-    {
-        return m_annotations;
-    }
-
-    public Collection<Annotation> getAnnotationList()
-    {
-        return m_annotations.values();
-    }
-
-    public boolean isAnnotationOptional()
-    {
-        Annotation ann = m_annotations.get("optional");
-        if (ann != null)
-        {
-            return ann.getValue().toUpperCase().equals("TRUE");
-        }
-        return false;
-    }
-
-    public boolean isAnnotationExternal()
-    {
-        Annotation ann = m_annotations.get("external");
-        if (ann != null)
-        {
-            return ann.getValue().toUpperCase().equals("TRUE");
-        }
-        return false;
-    }
-
-    public boolean isAnnotationMustUnderstand()
-    {
-        Annotation ann = m_annotations.get("must_understand");
-        if (ann != null)
-        {
-            return ann.getValue().toUpperCase().equals("TRUE");
-        }
-        return false;
-    }
-
-    public boolean isAnnotationNonSerialized()
-    {
-        Annotation ann = m_annotations.get("non_serialized");
-        if (ann != null)
-        {
-            return ann.getValue().toUpperCase().equals("TRUE");
-        }
-        return false;
-    }
-
-    public boolean isAnnotationKey()
-    {
-        Annotation ann = m_annotations.get("key");
-        if (ann == null)
-        {
-            ann = m_annotations.get("Key"); // Try old way
-        }
-        if (ann != null)
-        {
-            return ann.getValue().toUpperCase().equals("TRUE");
-        }
-        return false;
-    }
-
-    public Short getAnnotationBitBound()
-    {
-        Annotation ann = m_annotations.get("bit_bound");
-        if (ann != null)
-        {
-            String value = ann.getValue();
-            if (value.equals("-1"))
-            {
-                return null;
-            }
-            return Short.parseShort(value);
-        }
-        return null;
-    }
-
-    public boolean isAnnotationDefaultLiteral()
-    {
-        return m_annotations.get("default_literal") != null;
-    }
-
-    public String getAnnotationValue()
-    {
-        Annotation ann = m_annotations.get("value");
-        if (ann != null)
-        {
-            return ann.getValue();
-        }
-        return null;
-    }
-
-    public Short getAnnotationPosition()
-    {
-        Annotation ann = m_annotations.get("position");
-        if (ann != null)
-        {
-            String value = ann.getValue();
-            if (value.equals("-1"))
-            {
-                return null;
-            }
-            return Short.parseShort(value);
-        }
-        return null;
-    }
-
-    public boolean isAnnotationDefault()
-    {
-        return m_annotations.get("default") != null;
-    }
-
-    public String getAnnotationDefaultValue()
-    {
-        Annotation ann = m_annotations.get("default");
-        if (ann != null)
-        {
-            return ann.getValue();
-        }
-        return "";
-    }
-
     public boolean isIsPlain()
     {
         if (m_typecode != null && !isAnnotationOptional())
@@ -223,40 +80,6 @@ public class Member implements Notebook
             return m_typecode.isIsBounded();
         }
         return false;
-    }
-
-    public boolean isAnnotationId()
-    {
-        return null != m_annotations.get(Annotation.id_str);
-    }
-
-    public String getAnnotationIdValue() throws RuntimeGenerationException
-    {
-        Annotation ann = m_annotations.get(Annotation.id_str);
-        if (ann == null)
-        {
-            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.id_str +
-                    " annotation not found.");
-        }
-
-        return ann.getValue();
-    }
-
-    public boolean isAnnotationHashid()
-    {
-        return null != m_annotations.get(Annotation.hashid_str);
-    }
-
-    public String getAnnotationHashidValue() throws RuntimeGenerationException
-    {
-        Annotation ann = m_annotations.get(Annotation.hashid_str);
-        if (ann == null)
-        {
-            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.hashid_str +
-                    " annotation not found.");
-        }
-
-        return ann.getValue();
     }
 
     /*!
@@ -303,8 +126,6 @@ public class Member implements Notebook
     private String m_name = null;
 
     private TypeCode m_typecode = null;
-
-    private HashMap<String, Annotation> m_annotations = null;
 
     public static final int MEMBER_ID_INVALID = 0x0FFFFFFF;
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -47,7 +47,7 @@ public class MemberAppliedAnnotations implements Notebook
 
     public boolean isAnnotationOptional()
     {
-        Annotation ann = m_annotations.get("optional");
+        Annotation ann = m_annotations.get(Annotation.optional_str);
         if (ann != null)
         {
             return ann.getValue().toUpperCase().equals("TRUE");
@@ -57,7 +57,7 @@ public class MemberAppliedAnnotations implements Notebook
 
     public boolean isAnnotationExternal()
     {
-        Annotation ann = m_annotations.get("external");
+        Annotation ann = m_annotations.get(Annotation.external_str);
         if (ann != null)
         {
             return ann.getValue().toUpperCase().equals("TRUE");

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -19,11 +19,34 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.eprosima.idl.context.Context;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.Notebook;
 
 public class MemberAppliedAnnotations implements Notebook
 {
+    public enum TryConstructFailAction
+    {
+        INVALID(0),
+        DISCARD(1),
+        USE_DEFAULT(2),
+        TRIM(3);
+
+        private int value_ = 0;
+
+        private TryConstructFailAction(int value)
+        {
+            value_ = value;
+        }
+
+        public int get_value()
+        {
+            return value_;
+        }
+    };
+
+    public static TryConstructFailAction default_try_construct = TryConstructFailAction.DISCARD;
+
     @Override
     public void addAnnotation(Context ctx, Annotation annotation)
     {
@@ -49,7 +72,14 @@ public class MemberAppliedAnnotations implements Notebook
         Annotation ann = m_annotations.get(Annotation.optional_str);
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @optional annotation only has one parameter
+            }
         }
         return false;
     }
@@ -59,104 +89,226 @@ public class MemberAppliedAnnotations implements Notebook
         Annotation ann = m_annotations.get(Annotation.external_str);
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @external annotation has only one parameter
+            }
         }
         return false;
     }
 
     public boolean isAnnotationMustUnderstand()
     {
-        Annotation ann = m_annotations.get("must_understand");
+        Annotation ann = m_annotations.get(Annotation.must_understand_str);
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @must_understand annotation has only one parameter
+            }
         }
         return false;
     }
 
     public boolean isAnnotationNonSerialized()
     {
-        Annotation ann = m_annotations.get("non_serialized");
+        Annotation ann = m_annotations.get(Annotation.non_serialized_str);
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @non_serialized annotation has only one parameter
+            }
         }
         return false;
     }
 
     public boolean isAnnotationKey()
     {
-        Annotation ann = m_annotations.get("key");
+        Annotation ann = m_annotations.get(Annotation.key_str);
         if (ann == null)
         {
-            ann = m_annotations.get("Key"); // Try old way
+            ann = m_annotations.get(Annotation.eprosima_key_str); // Try old way
         }
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @key annotation has only one parameter
+            }
         }
         return false;
     }
 
-    public Short getAnnotationBitBound()
+    public boolean isAnnotationBitBound()
     {
-        Annotation ann = m_annotations.get("bit_bound");
-        if (ann != null)
+        return m_annotations.get(Annotation.bit_bound_str) != null;
+    }
+
+    public Short getAnnotationBitBoundValue() throws RuntimeGenerationException
+    {
+        try
         {
-            String value = ann.getValue();
-            if (value.equals("-1"))
+            if (isAnnotationBitBound())
             {
-                return null;
+                return Short.parseShort(m_annotations.get(Annotation.bit_bound_str).getValue());
             }
-            return Short.parseShort(value);
         }
-        return null;
+        catch (RuntimeGenerationException ex)
+        {
+            // Should never be called because isAnnotationBitBound() was previously called.
+        }
+        return 0;
     }
 
     public boolean isAnnotationDefaultLiteral()
     {
-        return m_annotations.get("default_literal") != null;
+        return m_annotations.get(Annotation.default_literal_str) != null;
     }
 
-    public String getAnnotationValue()
+    public boolean isAnnotationValue()
     {
-        Annotation ann = m_annotations.get("value");
-        if (ann != null)
-        {
-            return ann.getValue();
-        }
-        return null;
+        return m_annotations.get(Annotation.value_str) != null;
     }
 
-    public Short getAnnotationPosition()
+    public String getAnnotationValueValue()
     {
-        Annotation ann = m_annotations.get("position");
-        if (ann != null)
+        try
         {
-            String value = ann.getValue();
-            if (value.equals("-1"))
+            if (isAnnotationValue())
             {
-                return null;
+                return m_annotations.get(Annotation.value_str).getValue();
             }
-            return Short.parseShort(value);
         }
-        return null;
-    }
-
-    public boolean isAnnotationDefault()
-    {
-        return m_annotations.get("default") != null;
-    }
-
-    public String getAnnotationDefaultValue()
-    {
-        Annotation ann = m_annotations.get("default");
-        if (ann != null)
+        catch (RuntimeGenerationException ex)
         {
-            return ann.getValue();
+            // Should never be called because isAnnotationValue() was previously called.
         }
         return "";
     }
 
+    public boolean isAnnotationPosition()
+    {
+        return m_annotations.get(Annotation.position_str) != null;
+    }
+
+    public Short getAnnotationPositionValue()
+    {
+        try
+        {
+            if (isAnnotationPosition())
+            {
+                return Short.parseShort(m_annotations.get(Annotation.position_str).getValue());
+            }
+        }
+        catch (RuntimeGenerationException ex)
+        {
+            // Should never be called because isAnnotationPosition() was previously called.
+        }
+        return 0;
+    }
+
+    public boolean isAnnotationDefault()
+    {
+        return m_annotations.get(Annotation.default_str) != null;
+    }
+
+    public String getAnnotationDefaultValue() throws RuntimeGenerationException
+    {
+        Annotation ann = m_annotations.get(Annotation.default_str);
+        if (ann != null)
+        {
+            return ann.getValue();
+        }
+        throw new RuntimeGenerationException("Error getting @default annotation value: annotation not found");
+    }
+
+    public boolean isAnnotationTryConstruct()
+    {
+        return m_annotations.containsKey(Annotation.try_construct_str);
+    }
+
+    void calculate_try_construct() throws RuntimeGenerationException
+    {
+        if (TryConstructFailAction.INVALID == try_construct_)
+        {
+            if (isAnnotationTryConstruct())
+            {
+                if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_discard_str))
+                {
+                    try_construct_ = TryConstructFailAction.DISCARD;
+                }
+                else if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_use_default_str))
+                {
+                    try_construct_ = TryConstructFailAction.USE_DEFAULT;
+                }
+                else if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_trim_str))
+                {
+                    try_construct_ = TryConstructFailAction.TRIM;
+                }
+                else
+                {
+                    throw new RuntimeGenerationException("try_construct annotation does not have a recognized value");
+                }
+            }
+            else
+            {
+                try_construct_ = default_try_construct;
+            }
+        }
+    }
+
+    public TryConstructFailAction get_try_construct() throws RuntimeGenerationException
+    {
+        calculate_try_construct();
+        return try_construct_;
+    }
+
+    public boolean isAnnotationDiscard() throws RuntimeGenerationException
+    {
+        calculate_try_construct();
+        return TryConstructFailAction.DISCARD == try_construct_;
+    }
+
+    public boolean isAnnotationUseDefault() throws RuntimeGenerationException
+    {
+        calculate_try_construct();
+        return TryConstructFailAction.USE_DEFAULT == try_construct_;
+    }
+
+    public boolean isAnnotationTrim() throws RuntimeGenerationException
+    {
+        calculate_try_construct();
+        return TryConstructFailAction.TRIM == try_construct_;
+    }
+
+    public boolean isAnnotationId()
+    {
+        return m_annotations.get(Annotation.id_str) != null;
+    }
+
+    public boolean isAnnotationHashid()
+    {
+        return m_annotations.get(Annotation.hashid_str) != null;
+    }
+
     private HashMap<String, Annotation> m_annotations = new HashMap<String, Annotation>();
+
+    private TryConstructFailAction try_construct_ = TryConstructFailAction.INVALID;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -102,7 +102,8 @@ public class MemberAppliedAnnotations implements Notebook
         {
             return ann.getValue();
         }
-        throw new RuntimeGenerationException("Error getting @default annotation value: annotation not found");
+        throw new RuntimeGenerationException("Error getting @" + Annotation.default_str +
+                " annotation value: annotation not found");
     }
 
     public boolean isAnnotationDefaultLiteral()

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -67,21 +67,47 @@ public class MemberAppliedAnnotations implements Notebook
         return m_annotations.values();
     }
 
-    public boolean isAnnotationOptional()
+    //{{{ Auxiliary function to check which built-in annotation is the instance.
+
+    public boolean isAnnotationBitBound()
     {
-        Annotation ann = m_annotations.get(Annotation.optional_str);
-        if (ann != null)
+        return m_annotations.get(Annotation.bit_bound_str) != null;
+    }
+
+    public Short getAnnotationBitBoundValue() throws RuntimeGenerationException
+    {
+        try
         {
-            try
+            if (isAnnotationBitBound())
             {
-                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
-            }
-            catch (RuntimeGenerationException ex)
-            {
-                // Should not be called as @optional annotation only has one parameter
+                return Short.parseShort(m_annotations.get(Annotation.bit_bound_str).getValue());
             }
         }
-        return false;
+        catch (RuntimeGenerationException ex)
+        {
+            // Should never be called because isAnnotationBitBound() was previously called.
+        }
+        return 0;
+    }
+
+    public boolean isAnnotationDefault()
+    {
+        return m_annotations.get(Annotation.default_str) != null;
+    }
+
+    public String getAnnotationDefaultValue() throws RuntimeGenerationException
+    {
+        Annotation ann = m_annotations.get(Annotation.default_str);
+        if (ann != null)
+        {
+            return ann.getValue();
+        }
+        throw new RuntimeGenerationException("Error getting @default annotation value: annotation not found");
+    }
+
+    public boolean isAnnotationDefaultLiteral()
+    {
+        return m_annotations.get(Annotation.default_literal_str) != null;
     }
 
     public boolean isAnnotationExternal()
@@ -96,6 +122,37 @@ public class MemberAppliedAnnotations implements Notebook
             catch (RuntimeGenerationException ex)
             {
                 // Should not be called as @external annotation has only one parameter
+            }
+        }
+        return false;
+    }
+
+    public boolean isAnnotationHashid()
+    {
+        return m_annotations.get(Annotation.hashid_str) != null;
+    }
+
+    public boolean isAnnotationId()
+    {
+        return m_annotations.get(Annotation.id_str) != null;
+    }
+
+    public boolean isAnnotationKey()
+    {
+        Annotation ann = m_annotations.get(Annotation.key_str);
+        if (ann == null)
+        {
+            ann = m_annotations.get(Annotation.eprosima_key_str); // Try old way
+        }
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @key annotation has only one parameter
             }
         }
         return false;
@@ -135,13 +192,9 @@ public class MemberAppliedAnnotations implements Notebook
         return false;
     }
 
-    public boolean isAnnotationKey()
+    public boolean isAnnotationOptional()
     {
-        Annotation ann = m_annotations.get(Annotation.key_str);
-        if (ann == null)
-        {
-            ann = m_annotations.get(Annotation.eprosima_key_str); // Try old way
-        }
+        Annotation ann = m_annotations.get(Annotation.optional_str);
         if (ann != null)
         {
             try
@@ -150,57 +203,10 @@ public class MemberAppliedAnnotations implements Notebook
             }
             catch (RuntimeGenerationException ex)
             {
-                // Should not be called as @key annotation has only one parameter
+                // Should not be called as @optional annotation only has one parameter
             }
         }
         return false;
-    }
-
-    public boolean isAnnotationBitBound()
-    {
-        return m_annotations.get(Annotation.bit_bound_str) != null;
-    }
-
-    public Short getAnnotationBitBoundValue() throws RuntimeGenerationException
-    {
-        try
-        {
-            if (isAnnotationBitBound())
-            {
-                return Short.parseShort(m_annotations.get(Annotation.bit_bound_str).getValue());
-            }
-        }
-        catch (RuntimeGenerationException ex)
-        {
-            // Should never be called because isAnnotationBitBound() was previously called.
-        }
-        return 0;
-    }
-
-    public boolean isAnnotationDefaultLiteral()
-    {
-        return m_annotations.get(Annotation.default_literal_str) != null;
-    }
-
-    public boolean isAnnotationValue()
-    {
-        return m_annotations.get(Annotation.value_str) != null;
-    }
-
-    public String getAnnotationValueValue()
-    {
-        try
-        {
-            if (isAnnotationValue())
-            {
-                return m_annotations.get(Annotation.value_str).getValue();
-            }
-        }
-        catch (RuntimeGenerationException ex)
-        {
-            // Should never be called because isAnnotationValue() was previously called.
-        }
-        return "";
     }
 
     public boolean isAnnotationPosition()
@@ -224,21 +230,7 @@ public class MemberAppliedAnnotations implements Notebook
         return 0;
     }
 
-    public boolean isAnnotationDefault()
-    {
-        return m_annotations.get(Annotation.default_str) != null;
-    }
-
-    public String getAnnotationDefaultValue() throws RuntimeGenerationException
-    {
-        Annotation ann = m_annotations.get(Annotation.default_str);
-        if (ann != null)
-        {
-            return ann.getValue();
-        }
-        throw new RuntimeGenerationException("Error getting @default annotation value: annotation not found");
-    }
-
+    //{{{ @try_construct
     public boolean isAnnotationTryConstruct()
     {
         return m_annotations.containsKey(Annotation.try_construct_str);
@@ -297,16 +289,29 @@ public class MemberAppliedAnnotations implements Notebook
         calculate_try_construct();
         return TryConstructFailAction.TRIM == try_construct_;
     }
+    //}}}
 
-    public boolean isAnnotationId()
+    public boolean isAnnotationValue()
     {
-        return m_annotations.get(Annotation.id_str) != null;
+        return m_annotations.get(Annotation.value_str) != null;
     }
 
-    public boolean isAnnotationHashid()
+    public String getAnnotationValueValue()
     {
-        return m_annotations.get(Annotation.hashid_str) != null;
+        try
+        {
+            if (isAnnotationValue())
+            {
+                return m_annotations.get(Annotation.value_str).getValue();
+            }
+        }
+        catch (RuntimeGenerationException ex)
+        {
+            // Should never be called because isAnnotationValue() was previously called.
+        }
+        return "";
     }
+    //}}}
 
     private HashMap<String, Annotation> m_annotations = new HashMap<String, Annotation>();
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -1,0 +1,197 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.eprosima.idl.parser.typecode;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.eprosima.idl.context.Context;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.tree.Annotation;
+import com.eprosima.idl.parser.tree.Notebook;
+
+public class MemberAppliedAnnotations implements Notebook
+{
+    @Override
+    public void addAnnotation(Context ctx, Annotation annotation)
+    {
+        if(annotation != null)
+        {
+            m_annotations.put(annotation.getName(), annotation);
+        }
+    }
+
+    @Override
+    public Map<String, Annotation> getAnnotations()
+    {
+        return m_annotations;
+    }
+
+    public Collection<Annotation> getAnnotationList()
+    {
+        return m_annotations.values();
+    }
+
+    public boolean isAnnotationOptional()
+    {
+        Annotation ann = m_annotations.get("optional");
+        if (ann != null)
+        {
+            return ann.getValue().toUpperCase().equals("TRUE");
+        }
+        return false;
+    }
+
+    public boolean isAnnotationExternal()
+    {
+        Annotation ann = m_annotations.get("external");
+        if (ann != null)
+        {
+            return ann.getValue().toUpperCase().equals("TRUE");
+        }
+        return false;
+    }
+
+    public boolean isAnnotationMustUnderstand()
+    {
+        Annotation ann = m_annotations.get("must_understand");
+        if (ann != null)
+        {
+            return ann.getValue().toUpperCase().equals("TRUE");
+        }
+        return false;
+    }
+
+    public boolean isAnnotationNonSerialized()
+    {
+        Annotation ann = m_annotations.get("non_serialized");
+        if (ann != null)
+        {
+            return ann.getValue().toUpperCase().equals("TRUE");
+        }
+        return false;
+    }
+
+    public boolean isAnnotationKey()
+    {
+        Annotation ann = m_annotations.get("key");
+        if (ann == null)
+        {
+            ann = m_annotations.get("Key"); // Try old way
+        }
+        if (ann != null)
+        {
+            return ann.getValue().toUpperCase().equals("TRUE");
+        }
+        return false;
+    }
+
+    public Short getAnnotationBitBound()
+    {
+        Annotation ann = m_annotations.get("bit_bound");
+        if (ann != null)
+        {
+            String value = ann.getValue();
+            if (value.equals("-1"))
+            {
+                return null;
+            }
+            return Short.parseShort(value);
+        }
+        return null;
+    }
+
+    public boolean isAnnotationDefaultLiteral()
+    {
+        return m_annotations.get("default_literal") != null;
+    }
+
+    public String getAnnotationValue()
+    {
+        Annotation ann = m_annotations.get("value");
+        if (ann != null)
+        {
+            return ann.getValue();
+        }
+        return null;
+    }
+
+    public Short getAnnotationPosition()
+    {
+        Annotation ann = m_annotations.get("position");
+        if (ann != null)
+        {
+            String value = ann.getValue();
+            if (value.equals("-1"))
+            {
+                return null;
+            }
+            return Short.parseShort(value);
+        }
+        return null;
+    }
+
+    public boolean isAnnotationDefault()
+    {
+        return m_annotations.get("default") != null;
+    }
+
+    public String getAnnotationDefaultValue()
+    {
+        Annotation ann = m_annotations.get("default");
+        if (ann != null)
+        {
+            return ann.getValue();
+        }
+        return "";
+    }
+
+    public boolean isAnnotationId()
+    {
+        return null != m_annotations.get(Annotation.id_str);
+    }
+
+    public String getAnnotationIdValue() throws RuntimeGenerationException
+    {
+        Annotation ann = m_annotations.get(Annotation.id_str);
+        if (ann == null)
+        {
+            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.id_str +
+                    " annotation not found.");
+        }
+
+        return ann.getValue();
+    }
+
+    public boolean isAnnotationHashid()
+    {
+        return null != m_annotations.get(Annotation.hashid_str);
+    }
+
+    public String getAnnotationHashidValue() throws RuntimeGenerationException
+    {
+        Annotation ann = m_annotations.get(Annotation.hashid_str);
+        if (ann == null)
+        {
+            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.hashid_str +
+                    " annotation not found.");
+        }
+
+        return ann.getValue();
+    }
+
+    private HashMap<String, Annotation> m_annotations = new HashMap<String, Annotation>();
+}

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.eprosima.idl.context.Context;
-import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.Notebook;
 
@@ -157,40 +156,6 @@ public class MemberAppliedAnnotations implements Notebook
             return ann.getValue();
         }
         return "";
-    }
-
-    public boolean isAnnotationId()
-    {
-        return null != m_annotations.get(Annotation.id_str);
-    }
-
-    public String getAnnotationIdValue() throws RuntimeGenerationException
-    {
-        Annotation ann = m_annotations.get(Annotation.id_str);
-        if (ann == null)
-        {
-            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.id_str +
-                    " annotation not found.");
-        }
-
-        return ann.getValue();
-    }
-
-    public boolean isAnnotationHashid()
-    {
-        return null != m_annotations.get(Annotation.hashid_str);
-    }
-
-    public String getAnnotationHashidValue() throws RuntimeGenerationException
-    {
-        Annotation ann = m_annotations.get(Annotation.hashid_str);
-        if (ann == null)
-        {
-            throw new RuntimeGenerationException("Error in member " + m_name + ": @" + Annotation.hashid_str +
-                    " annotation not found.");
-        }
-
-        return ann.getValue();
     }
 
     private HashMap<String, Annotation> m_annotations = new HashMap<String, Annotation>();

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -144,18 +144,20 @@ public abstract class MemberedTypeCode extends TypeCode
                     Kind.KIND_ENUM != getKind() && Kind.KIND_BITMASK != getKind()))
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @bit_bound annotations only supported for enumeration's members or bitmask's members.");
+                    ": @" + Annotation.bit_bound_str +
+                    " annotations only supported for enumeration's members or bitmask's members.");
         }
         if (member.isAnnotationDefaultLiteral() && Kind.KIND_ENUM != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @default_literal annotations only supported for enumeration's members.");
+                    ": @" + Annotation.default_literal_str + " annotations only supported for enumeration's members.");
         }
         if (member.isAnnotationExternal() && (
                     Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.external_str + " annotations only supported for structure's members or union's members.");
+                    ": @" + Annotation.external_str +
+                    " annotations only supported for structure's members or union's members.");
         }
         if (member.isAnnotationHashid() && (
                     Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
@@ -174,17 +176,18 @@ public abstract class MemberedTypeCode extends TypeCode
         if (member.isAnnotationKey() && Kind.KIND_STRUCT != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.key_str + " annotations only supported for structure's members (Union discriminator still pending implementation).");
+                    ": @" + Annotation.key_str +
+                    " annotations only supported for structure's members (Union discriminator still pending implementation).");
         }
         if (member.isAnnotationMustUnderstand() && Kind.KIND_STRUCT != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @must_understand annotations only supported for structure's members.");
+                    ": @" + Annotation.must_understand_str + " annotations only supported for structure's members.");
         }
         if (member.isAnnotationNonSerialized() && Kind.KIND_STRUCT != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @non_serialized annotations only supported for structure's members.");
+                    ": @" + Annotation.non_serialized_str + " annotations only supported for structure's members.");
         }
         if (member.isAnnotationOptional() && Kind.KIND_STRUCT != getKind())
         {
@@ -194,18 +197,19 @@ public abstract class MemberedTypeCode extends TypeCode
         if (member.isAnnotationPosition() && Kind.KIND_BITMASK != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @position annotations only supported for bitmask's members.");
+                    ": @" + Annotation.position_str + " annotations only supported for bitmask's members.");
         }
         if (member.isAnnotationValue() && Kind.KIND_ENUM != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @value annotations only supported for enumeration's members.");
+                    ": @" + Annotation.value_str + " annotations only supported for enumeration's members.");
         }
 
         if(member.isAnnotationKey() && member.isAnnotationNonSerialized())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.key_str + " and @non_serialized annotations are incompatible.");
+                    ": @" + Annotation.key_str + " and @" + Annotation.non_serialized_str +
+                    " annotations are incompatible.");
         }
         if(member.isAnnotationKey() && member.isAnnotationOptional())
         {

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -41,14 +41,14 @@ public abstract class MemberedTypeCode extends TypeCode
 
     /*!
      * @brief Returns the full scoped name of the type, unless the developer uses
-     * `TemplateSTGroup.enable_using_explicitly_modules()`, by removing from the full scoped name the current
-     * `Context` scope.
+     * `TemplateSTGroup.enable_custom_proeprty("using_explicitly_modules")`, by removing from the full scoped name the
+     * current `Context` scope.
      */
     public String getScopedname()
     {
         String scoped_name = getFullScopedname();
 
-        if (!ctx.get_template_manager().get_current_template_stgroup().is_enabled_using_explicitly_modules())
+        if (!ctx.is_enabled_custom_property_in_current_group(ctx.using_explicitly_modules_custom_property))
         {
             return scoped_name;
         }

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -138,13 +138,13 @@ public abstract class MemberedTypeCode extends TypeCode
         if (member.isAnnotationOptional() && Kind.KIND_STRUCT != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @optional annotations only supported for structure's members.");
+                    ": @" + Annotation.optional_str +" annotations only supported for structure's members.");
         }
         if (member.isAnnotationExternal() && (
                     Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @external annotations only supported for structure's members or union's members.");
+                    ": @" + Annotation.external_str + " annotations only supported for structure's members or union's members.");
         }
         if (member.isAnnotationMustUnderstand() && Kind.KIND_STRUCT != getKind())
         {
@@ -190,7 +190,7 @@ public abstract class MemberedTypeCode extends TypeCode
         if(member.isAnnotationKey() && member.isAnnotationOptional())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.key_str + " and @optional annotations are incompatible.");
+                    ": @" + Annotation.key_str + " and @" + Annotation.optional_str + " annotations are incompatible.");
         }
         if (member.isAnnotationId() && (
                     Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -139,33 +139,7 @@ public abstract class MemberedTypeCode extends TypeCode
     public boolean addMember(
             Member member) throws ParseException
     {
-        // Check annotations.
-        if (member.isAnnotationOptional() && Kind.KIND_STRUCT != getKind())
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.optional_str +" annotations only supported for structure's members.");
-        }
-        if (member.isAnnotationExternal() && (
-                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.external_str + " annotations only supported for structure's members or union's members.");
-        }
-        if (member.isAnnotationMustUnderstand() && Kind.KIND_STRUCT != getKind())
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @must_understand annotations only supported for structure's members.");
-        }
-        if (member.isAnnotationNonSerialized() && Kind.KIND_STRUCT != getKind())
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @non_serialized annotations only supported for structure's members.");
-        }
-        if (member.isAnnotationKey() && Kind.KIND_STRUCT != getKind())
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.key_str + " annotations only supported for structure's members (Union discriminator still pending implementation).");
-        }
+        //{{{ Check annotations.
         if (member.isAnnotationBitBound() && (
                     Kind.KIND_ENUM != getKind() && Kind.KIND_BITMASK != getKind()))
         {
@@ -177,16 +151,57 @@ public abstract class MemberedTypeCode extends TypeCode
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @default_literal annotations only supported for enumeration's members.");
         }
-        if (member.isAnnotationValue() && Kind.KIND_ENUM != getKind())
+        if (member.isAnnotationExternal() && (
+                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
         {
             throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @value annotations only supported for enumeration's members.");
+                    ": @" + Annotation.external_str + " annotations only supported for structure's members or union's members.");
+        }
+        if (member.isAnnotationHashid() && (
+                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @" + Annotation.hashid_str +
+                    "annotations only supported for structure's members or union's members.");
+        }
+        if (member.isAnnotationId() && (
+                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @" + Annotation.id_str +
+                    " annotations only supported for structure's members or union's members.");
+        }
+        if (member.isAnnotationKey() && Kind.KIND_STRUCT != getKind())
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @" + Annotation.key_str + " annotations only supported for structure's members (Union discriminator still pending implementation).");
+        }
+        if (member.isAnnotationMustUnderstand() && Kind.KIND_STRUCT != getKind())
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @must_understand annotations only supported for structure's members.");
+        }
+        if (member.isAnnotationNonSerialized() && Kind.KIND_STRUCT != getKind())
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @non_serialized annotations only supported for structure's members.");
+        }
+        if (member.isAnnotationOptional() && Kind.KIND_STRUCT != getKind())
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @" + Annotation.optional_str +" annotations only supported for structure's members.");
         }
         if (member.isAnnotationPosition() && Kind.KIND_BITMASK != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @position annotations only supported for bitmask's members.");
         }
+        if (member.isAnnotationValue() && Kind.KIND_ENUM != getKind())
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": @value annotations only supported for enumeration's members.");
+        }
+
         if(member.isAnnotationKey() && member.isAnnotationNonSerialized())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
@@ -197,25 +212,12 @@ public abstract class MemberedTypeCode extends TypeCode
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @" + Annotation.key_str + " and @" + Annotation.optional_str + " annotations are incompatible.");
         }
-        if (member.isAnnotationId() && (
-                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.id_str +
-                    " annotations only supported for structure's members or union's members.");
-        }
-        if (member.isAnnotationHashid() && (
-                    Kind.KIND_STRUCT != getKind() && Kind.KIND_UNION != getKind()))
-        {
-            throw new ParseException(null, "Error in member " + member.getName() +
-                    ": @" + Annotation.hashid_str +
-                    "annotations only supported for structure's members or union's members.");
-        }
         if (member.isAnnotationId() && member.isAnnotationHashid())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @" + Annotation.id_str + " and @" + Annotation.hashid_str + " annotations cannot be together.");
         }
+        //}}}
 
         if(!m_members.containsKey(member.getName()))
         {

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -39,10 +39,39 @@ public abstract class MemberedTypeCode extends TypeCode
         return m_name;
     }
 
+    /*!
+     * @brief Returns the full scoped name of the type, unless the developer uses
+     * `TemplateSTGroup.enable_using_explicitly_modules()`, by removing from the full scoped name the current
+     * `Context` scope.
+     */
     public String getScopedname()
     {
+        String scoped_name = getFullScopedname();
+
+        if (!ctx.get_template_manager().get_current_template_stgroup().is_enabled_using_explicitly_modules())
+        {
+            return scoped_name;
+        }
+
+        String current_scope = ctx.getScope();
+
+        if(current_scope.isEmpty() || !scoped_name.startsWith(current_scope + "::"))
+        {
+            return scoped_name;
+        }
+
+        return scoped_name.replace(current_scope + "::", "");
+    }
+
+    /*!
+     * @brief Return the scoped name of the type.
+     */
+    public String getFullScopedname()
+    {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope + "::" + m_name;
     }
@@ -50,7 +79,9 @@ public abstract class MemberedTypeCode extends TypeCode
     public String getROS2Scopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope + "::dds_::" + m_name + "_";
     }
@@ -58,7 +89,9 @@ public abstract class MemberedTypeCode extends TypeCode
     public String getCScopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope.replace("::", "_") + "_" + m_name;
     }
@@ -66,7 +99,9 @@ public abstract class MemberedTypeCode extends TypeCode
     public String getJavaScopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope.replace("::", ".") + "." + m_name;
     }
@@ -74,7 +109,9 @@ public abstract class MemberedTypeCode extends TypeCode
     public String getJniScopedname()
     {
         if(m_scope.isEmpty())
+        {
             return m_name;
+        }
 
         return m_scope.replace("::", "/") + "/" + m_name;
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -131,6 +131,11 @@ public abstract class MemberedTypeCode extends TypeCode
         return new ArrayList<Member>(m_members.values());
     }
 
+    public int getMembersSize()
+    {
+        return m_members.size();
+    }
+
     public boolean addMember(
             Member member) throws ParseException
     {
@@ -161,7 +166,7 @@ public abstract class MemberedTypeCode extends TypeCode
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @" + Annotation.key_str + " annotations only supported for structure's members (Union discriminator still pending implementation).");
         }
-        if (null != member.getAnnotationBitBound() && (
+        if (member.isAnnotationBitBound() && (
                     Kind.KIND_ENUM != getKind() && Kind.KIND_BITMASK != getKind()))
         {
             throw new ParseException(null, "Error in member " + member.getName() +
@@ -172,12 +177,12 @@ public abstract class MemberedTypeCode extends TypeCode
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @default_literal annotations only supported for enumeration's members.");
         }
-        if (null != member.getAnnotationValue() && Kind.KIND_ENUM != getKind())
+        if (member.isAnnotationValue() && Kind.KIND_ENUM != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @value annotations only supported for enumeration's members.");
         }
-        if (null != member.getAnnotationPosition() && Kind.KIND_BITMASK != getKind())
+        if (member.isAnnotationPosition() && Kind.KIND_BITMASK != getKind())
         {
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @position annotations only supported for bitmask's members.");
@@ -204,7 +209,7 @@ public abstract class MemberedTypeCode extends TypeCode
         {
             throw new ParseException(null, "Error in member " + member.getName() +
                     ": @" + Annotation.hashid_str +
-                     "annotations only supported for structure's members or union's members.");
+                    "annotations only supported for structure's members or union's members.");
         }
         if (member.isAnnotationId() && member.isAnnotationHashid())
         {
@@ -273,7 +278,7 @@ public abstract class MemberedTypeCode extends TypeCode
         }
         catch (RuntimeGenerationException ex)
         {
-            // Should be never called because was previously called isAnnotationId() or similar.
+            // Should never be called because isAnnotationId() or similar was previously called.
         }
     }
 
@@ -395,6 +400,18 @@ public abstract class MemberedTypeCode extends TypeCode
         }
 
         return ann.getValue();
+    }
+
+    public boolean isNonForwardedContent()
+    {
+        for (Member member : m_members.values())
+        {
+            if (member.getTypecode().isForwarded())
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private String m_name = null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/PrimitiveTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/PrimitiveTypeCode.java
@@ -183,9 +183,93 @@ public class PrimitiveTypeCode extends TypeCode
     }
 
     @Override
+    public boolean isIsCharType()
+    {
+        return getKind() == Kind.KIND_CHAR;
+    }
+
+    @Override
     public boolean isIsWCharType()
     {
         return getKind() == Kind.KIND_WCHAR;
+    }
+
+    @Override
+    public boolean isIsBooleanType()
+    {
+        return getKind() == Kind.KIND_BOOLEAN;
+    }
+
+    @Override
+    public boolean isIsByteType()
+    {
+        return getKind() == Kind.KIND_OCTET;
+    }
+
+    @Override
+    public boolean isIsInt8Type()
+    {
+        return getKind() == Kind.KIND_INT8;
+    }
+
+    @Override
+    public boolean isIsUint8Type()
+    {
+        return getKind() == Kind.KIND_UINT8;
+    }
+
+    @Override
+    public boolean isIsInt16Type()
+    {
+        return getKind() == Kind.KIND_SHORT;
+    }
+
+    @Override
+    public boolean isIsUint16Type()
+    {
+        return getKind() == Kind.KIND_USHORT;
+    }
+
+    @Override
+    public boolean isIsInt32Type()
+    {
+        return getKind() == Kind.KIND_LONG;
+    }
+
+    @Override
+    public boolean isIsUint32Type()
+    {
+        return getKind() == Kind.KIND_ULONG;
+    }
+
+    @Override
+    public boolean isIsInt64Type()
+    {
+        return getKind() == Kind.KIND_LONGLONG;
+    }
+
+    @Override
+    public boolean isIsUint64Type()
+    {
+        return getKind() == Kind.KIND_ULONGLONG;
+    }
+
+    @Override
+    public boolean isIsFloat32Type()
+    {
+        return getKind() == Kind.KIND_FLOAT;
+    }
+
+    @Override
+    public boolean isIsFloat64Type()
+    {
+        return getKind() == Kind.KIND_DOUBLE;
+    }
+
+    @Override
+    public boolean isIsFloat128Type()
+    {
+        return getKind() == Kind.KIND_LONGDOUBLE;
     }
 
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -39,6 +39,10 @@ public class SequenceTypeCode extends ContainerTypeCode
     @Override
     public String getTypeIdentifier()
     {
+        if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+        {
+            return "TI_PLAIN_SEQUENCE_LARGE";
+        }
         return "TI_PLAIN_SEQUENCE_SMALL";
     }
 
@@ -119,6 +123,7 @@ public class SequenceTypeCode extends ContainerTypeCode
         return m_maxsize;
     }
 
+    @Override
     public String getEvaluatedMaxsize()
     {
         if (evaluated_maxsize_ == null)

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -113,7 +113,7 @@ public class SequenceTypeCode extends ContainerTypeCode
     {
         if (m_maxsize == null)
         {
-            return "100";
+            return default_unbounded_max_size;
         }
 
         return m_maxsize;

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -39,7 +39,7 @@ public class SequenceTypeCode extends ContainerTypeCode
     @Override
     public String getTypeIdentifier()
     {
-        if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+        if (!isUnbound() && Integer.parseInt(evaluated_maxsize_) >= 256)
         {
             return "TI_PLAIN_SEQUENCE_LARGE";
         }
@@ -134,6 +134,10 @@ public class SequenceTypeCode extends ContainerTypeCode
         return evaluated_maxsize_;
     }
 
+    /**
+     * This API is to check if this specific collection has a bound set.
+     * It does not check if the complete collection is bounded or not.
+     */
     public boolean isUnbound()
     {
         return null == m_maxsize;
@@ -145,6 +149,10 @@ public class SequenceTypeCode extends ContainerTypeCode
         return false;
     }
 
+    /**
+     * This API is to check if ultimately the collection element is bounded.
+     * In order to check if this specific collection has bounds, please use isUnbound API.
+     */
     @Override
     public boolean isIsBounded()
     {

--- a/src/main/java/com/eprosima/idl/parser/typecode/SetTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SetTypeCode.java
@@ -92,7 +92,7 @@ public class SetTypeCode extends ContainerTypeCode
     {
         if (m_maxsize == null)
         {
-            return "100";
+            return default_unbounded_max_size;
         }
 
         return m_maxsize;

--- a/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
@@ -42,9 +42,23 @@ public class StringTypeCode extends TypeCode
         switch (getKind())
         {
             case Kind.KIND_STRING:
-                return "TI_STRING8_SMALL";
+                if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+                {
+                    return "TI_STRING8_LARGE";
+                }
+                else
+                {
+                    return "TI_STRING8_SMALL";
+                }
             case Kind.KIND_WSTRING:
-                return "TI_STRING16_SMALL";
+                if (isIsBounded() && Integer.parseInt(evaluated_maxsize_) >= 256)
+                {
+                    return "TI_STRING16_LARGE";
+                }
+                else
+                {
+                    return "TI_STRING16_SMALL";
+                }
             default:
                 return "TK_None";
         }
@@ -96,6 +110,7 @@ public class StringTypeCode extends TypeCode
         return getIdlTypenameFromStringTemplate().toString();
     }
 
+    @Override
     public String getMaxsize()
     {
         if (m_maxsize == null)
@@ -106,6 +121,7 @@ public class StringTypeCode extends TypeCode
         return m_maxsize;
     }
 
+    @Override
     public String getEvaluatedMaxsize()
     {
         if (evaluated_maxsize_ == null)

--- a/src/main/java/com/eprosima/idl/parser/typecode/StructTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/StructTypeCode.java
@@ -22,6 +22,7 @@ import org.stringtemplate.v4.ST;
 
 import com.eprosima.idl.context.Context;
 import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.Inherits;
 
@@ -163,6 +164,17 @@ public class StructTypeCode extends MemberedTypeCode implements Inherits
         return allMembers;
     }
 
+    public Member getFirstMember() throws RuntimeGenerationException
+    {
+        List<Member> members = getMembers();
+        if (members.size() == 0)
+        {
+            throw new RuntimeGenerationException("Error in structure " + super.getName() +
+                    ": trying accesing first member of an empty structure");
+        }
+        return members.get(0);
+    }
+
     public List<Member> getAllMembers() // Alias for getMembers(true) for stg
     {
         return getMembers(true);
@@ -236,6 +248,17 @@ public class StructTypeCode extends MemberedTypeCode implements Inherits
         }
         calculate_member_id_(member);
         return super.addMember(member);
+    }
+
+    @Override
+    public boolean isNonForwardedContent()
+    {
+        boolean ret_code = true;
+        if (super_type_ != null)
+        {
+            ret_code &= super_type_.isNonForwardedContent(); 
+        }
+        return ret_code &= super.isNonForwardedContent();
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/StructTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/StructTypeCode.java
@@ -93,7 +93,6 @@ public class StructTypeCode extends MemberedTypeCode implements Inherits
             TypeCode parent) throws ParseException
     {
         String name = parent.getClass().getSimpleName();
-        System.out.println("type = " + name);
 
         if (super_type_ == null && parent instanceof StructTypeCode)
         {
@@ -254,9 +253,9 @@ public class StructTypeCode extends MemberedTypeCode implements Inherits
     public boolean isNonForwardedContent()
     {
         boolean ret_code = true;
-        if (super_type_ != null)
+        if (enclosed_super_type_ != null)
         {
-            ret_code &= super_type_.isNonForwardedContent(); 
+            ret_code &= enclosed_super_type_.isNonForwardedContent();
         }
         return ret_code &= super.isNonForwardedContent();
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -130,7 +130,7 @@ public abstract class TypeCode implements Notebook
     }
 
     /*!
-     * @brief
+     * @brief Return the `getCppTypename()` without the scope.
      */
     public String getNoScopedCppTypename()
     {

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -14,16 +14,16 @@
 
 package com.eprosima.idl.parser.typecode;
 
-import com.eprosima.idl.parser.tree.Annotation;
-import com.eprosima.idl.parser.tree.Notebook;
-import com.eprosima.idl.context.Context;
-
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 
+import com.eprosima.idl.context.Context;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
+import com.eprosima.idl.parser.tree.Annotation;
+import com.eprosima.idl.parser.tree.Notebook;
 
 
 public abstract class TypeCode implements Notebook
@@ -161,6 +161,11 @@ public abstract class TypeCode implements Notebook
         return null;
     }
 
+    public String getEvaluatedMaxsize() throws RuntimeGenerationException
+    {
+        throw new RuntimeGenerationException("Non-collection types does not have an evaluated max size");
+    }
+
     /*!
      * @brief This function returns the size of the datatype. By default is null string.
      * @return The size of the datatype.
@@ -222,6 +227,76 @@ public abstract class TypeCode implements Notebook
         return false;
     }
 
+    public boolean isIsBooleanType()
+    {
+        return false;
+    }
+
+    public boolean isIsByteType()
+    {
+        return false;
+    }
+
+    public boolean isIsInt8Type()
+    {
+        return false;
+    }
+
+    public boolean isIsUint8Type()
+    {
+        return false;
+    }
+
+    public boolean isIsInt16Type()
+    {
+        return false;
+    }
+
+    public boolean isIsUint16Type()
+    {
+        return false;
+    }
+
+    public boolean isIsInt32Type()
+    {
+        return false;
+    }
+
+    public boolean isIsUint32Type()
+    {
+        return false;
+    }
+
+    public boolean isIsInt64Type()
+    {
+        return false;
+    }
+
+    public boolean isIsUint64Type()
+    {
+        return false;
+    }
+
+    public boolean isIsFloat32Type()
+    {
+        return false;
+    }
+
+    public boolean isIsFloat64Type()
+    {
+        return false;
+    }
+
+    public boolean isIsFloat128Type()
+    {
+        return false;
+    }
+
+    public boolean isIsEnumType()
+    {
+        return false;
+    }
+
     public boolean isIsBitmaskType()
     {
         return false;
@@ -242,12 +317,12 @@ public abstract class TypeCode implements Notebook
         return false;
     }
 
-    public boolean isIsWCharType()
+    public boolean isIsCharType()
     {
         return false;
     }
 
-    public boolean isIsEnumType()
+    public boolean isIsWCharType()
     {
         return false;
     }
@@ -365,34 +440,41 @@ public abstract class TypeCode implements Notebook
     {
         if (ExtensibilityKind.NOT_APPLIED == extensibility_)
         {
-            if (m_annotations.containsKey(Annotation.final_str) ||
-                    (m_annotations.containsKey(Annotation.extensibility_str) &&
-                     m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_final_val)))
+            try
             {
-                extensibility_ = ExtensibilityKind.FINAL;
-            }
-            else if (m_annotations.containsKey(Annotation.appendable_str) ||
-                    (m_annotations.containsKey(Annotation.extensibility_str) &&
-                     m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_appendable_val)))
-            {
-                extensibility_ = ExtensibilityKind.APPENDABLE;
-            }
-            else if (m_annotations.containsKey(Annotation.mutable_str) ||
-                    (m_annotations.containsKey(Annotation.extensibility_str) &&
-                     m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_mutable_val)))
-            {
-                extensibility_ = ExtensibilityKind.MUTABLE;
-            }
-            else
-            {
-                if (ExtensibilityKind.NOT_APPLIED != base_ext)
+                if (m_annotations.containsKey(Annotation.final_str) ||
+                        (m_annotations.containsKey(Annotation.extensibility_str) &&
+                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_final_val)))
                 {
-                    extensibility_ = base_ext;
+                    extensibility_ = ExtensibilityKind.FINAL;
+                }
+                else if (m_annotations.containsKey(Annotation.appendable_str) ||
+                        (m_annotations.containsKey(Annotation.extensibility_str) &&
+                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_appendable_val)))
+                {
+                    extensibility_ = ExtensibilityKind.APPENDABLE;
+                }
+                else if (m_annotations.containsKey(Annotation.mutable_str) ||
+                        (m_annotations.containsKey(Annotation.extensibility_str) &&
+                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_mutable_val)))
+                {
+                    extensibility_ = ExtensibilityKind.MUTABLE;
                 }
                 else
                 {
-                    extensibility_ = default_extensibility;
+                    if (ExtensibilityKind.NOT_APPLIED != base_ext)
+                    {
+                        extensibility_ = base_ext;
+                    }
+                    else
+                    {
+                        extensibility_ = default_extensibility;
+                    }
                 }
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @extensibility annotation has only one parameter
             }
         }
     }
@@ -427,12 +509,49 @@ public abstract class TypeCode implements Notebook
         return ExtensibilityKind.MUTABLE == extensibility_;
     }
 
+    public boolean isAnnotationExtensibilityNotApplied()
+    {
+        if (!m_annotations.containsKey(Annotation.final_str) &&
+                !m_annotations.containsKey(Annotation.appendable_str) &&
+                !m_annotations.containsKey(Annotation.mutable_str) &&
+                !m_annotations.containsKey(Annotation.extensibility_str))
+        {
+            return true;
+        }
+        return false;
+    }
+
     public boolean isAnnotationNested()
     {
-        Annotation ann = m_annotations.get("nested");
+        Annotation ann = m_annotations.get(Annotation.nested_str);
         if (ann != null)
         {
-            return ann.getValue().toUpperCase().equals("TRUE");
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @nested annotation has only one parameter
+            }
+        }
+        return false;
+    }
+
+    public boolean isAnnotationAutoidHash()
+    {
+        Annotation ann = m_annotations.get(Annotation.autoid_str);
+        if (ann != null)
+        {
+            try
+            {
+                return (ann.getValue().toUpperCase().equals(Annotation.autoid_hash_value_str) ||
+                        ann.getValue().isEmpty());
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @autoid annotation has only one parameter
+            }
         }
         return false;
     }
@@ -470,4 +589,5 @@ public abstract class TypeCode implements Notebook
     private boolean m_defined = false;
 
     private ExtensibilityKind extensibility_ = ExtensibilityKind.NOT_APPLIED;
+
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionMember.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionMember.java
@@ -60,11 +60,6 @@ public class UnionMember extends Member
         return m_default;
     }
 
-    public boolean isPrintable()
-    {
-        return m_default || (null != m_labels && 0 < m_labels.size());
-    }
-
     private List<String> m_internallabels = null;
     private List<String> m_labels = null;
     private List<String> m_javalabels = null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionMember.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionMember.java
@@ -35,6 +35,11 @@ public class UnionMember extends Member
         return m_labels;
     }
 
+    public int getLabelsSize()
+    {
+        return m_labels.size();
+    }
+
     public void setLabels(List<String> labels)
     {
         m_labels = labels;

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -233,33 +233,6 @@ public class UnionTypeCode extends MemberedTypeCode
         return false;
     }
 
-    // Add member and the default one at the end.
-    public List<Member> getMembersDefaultAtEnd()
-    {
-        int position = 0;
-        List<Member> ret_members = new ArrayList<Member>();
-        Member default_member = null;
-
-        for (Member m : getMembers())
-        {
-            if (position == m_defaultindex)
-            {
-                default_member = m;
-            }
-            else
-            {
-                ret_members.add(m);
-            }
-        }
-
-        if (null != default_member)
-        {
-            ret_members.add(default_member);
-        }
-
-        return ret_members;
-    }
-
     @Override
     public void addAnnotation(
             Context ctx,

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -34,7 +34,7 @@ public class UnionTypeCode extends MemberedTypeCode
             String name)
     {
         super(Kind.KIND_UNION, scope, name);
-        m_discriminatorTypeCode = null;
+        discriminator_ = null;
     }
 
     public UnionTypeCode(
@@ -43,7 +43,7 @@ public class UnionTypeCode extends MemberedTypeCode
             TypeCode discriminatorTypeCode)
     {
         super(Kind.KIND_UNION, scope, name);
-        m_discriminatorTypeCode = discriminatorTypeCode;
+        discriminator_ = new UnionMember(discriminatorTypeCode, "discriminator", null, false);
         ++last_index_;
         ++last_id_;
     }
@@ -51,7 +51,7 @@ public class UnionTypeCode extends MemberedTypeCode
     public void setDiscriminatorType(
             TypeCode discriminatorTypeCode) throws RuntimeGenerationException
     {
-        m_discriminatorTypeCode = discriminatorTypeCode;
+        discriminator_ = new UnionMember(discriminatorTypeCode, "discriminator", null, false);
         ++last_index_;
         ++last_id_;
         if(last_id_ != 0)
@@ -101,10 +101,10 @@ public class UnionTypeCode extends MemberedTypeCode
         List<String> labels = null;
         List<String> javalabels = null;
 
-        if (Kind.KIND_ENUM == m_discriminatorTypeCode.getKind() ||
-                Kind.KIND_BITMASK == m_discriminatorTypeCode.getKind())
+        if (Kind.KIND_ENUM == discriminator_.getTypecode().getKind() ||
+                Kind.KIND_BITMASK == discriminator_.getTypecode().getKind())
         {
-            MemberedTypeCode enum_type = (MemberedTypeCode)m_discriminatorTypeCode;
+            MemberedTypeCode enum_type = (MemberedTypeCode)discriminator_.getTypecode();
             labels = new ArrayList<String>();
             javalabels = new ArrayList<String>();
 
@@ -199,9 +199,9 @@ public class UnionTypeCode extends MemberedTypeCode
     }
 
     // Used in stringtemplates
-    public TypeCode getDiscriminator()
+    public UnionMember getDiscriminator()
     {
-        return m_discriminatorTypeCode;
+        return discriminator_;
     }
 
     // Used in stringtemplates
@@ -270,7 +270,7 @@ public class UnionTypeCode extends MemberedTypeCode
         super.addAnnotation(ctx, annotation);
     }
 
-    private TypeCode m_discriminatorTypeCode = null;
+    private UnionMember discriminator_ = null;
 
     private int m_defaultindex = -1;
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -110,7 +110,8 @@ public class UnionTypeCode extends MemberedTypeCode
 
             for (int count = 0; count < internal_labels.size(); ++count)
             {
-                labels.add(enum_type.getScope() + "::" + internal_labels.get(count));
+                labels.add((Kind.KIND_ENUM == discriminator_.getTypecode().getKind() ?
+                            enum_type.getScopedname() + "::" : "")+ internal_labels.get(count));
                 javalabels.add(javapackage + enum_type.getJavaScopedname() + "." + internal_labels.get(count));
             }
         }

--- a/src/main/java/com/eprosima/idl/test/TestIDLParser.java
+++ b/src/main/java/com/eprosima/idl/test/TestIDLParser.java
@@ -324,7 +324,7 @@ public class TestIDLParser {
     }
 
     public void parseUnion(UnionTypeCode union) {
-        System.out.println("Start Union: " + union.getName() + " (" + union.getDiscriminator().getTypeIdentifier() + ")");
+        System.out.println("Start Union: " + union.getName() + " (" + union.getDiscriminator().getTypecode().getTypeIdentifier() + ")");
         for (Member member: union.getMembers()) {
             parseUnionMember((UnionMember)member);
         }

--- a/src/main/java/com/eprosima/idl/test/TestIDLParser.java
+++ b/src/main/java/com/eprosima/idl/test/TestIDLParser.java
@@ -19,6 +19,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 
 
 import com.eprosima.idl.context.Context;
+import com.eprosima.idl.generator.manager.TemplateManager;
 import com.eprosima.idl.parser.grammar.IDLLexer;
 import com.eprosima.idl.parser.grammar.IDLParser;
 import com.eprosima.idl.parser.tree.Annotation;
@@ -75,7 +76,8 @@ public class TestIDLParser {
             return;
         }
 
-        Context context = new Context(idlFileName, m_includePaths);
+        TemplateManager tmanager = new TemplateManager();
+        Context context = new Context(tmanager, idlFileName, m_includePaths, false);
 
         try {
 

--- a/src/main/java/com/eprosima/solution/Project.java
+++ b/src/main/java/com/eprosima/solution/Project.java
@@ -30,6 +30,7 @@ public class Project
         m_commonsrcfiles = new ArrayList<String>();
         m_commonincludefiles = new ArrayList<String>();
         m_commontestingfiles = new ArrayList<String>();
+        m_typeobjecttestingfiles = new ArrayList<String>();
     }
 
     public void setParent(Solution sol)
@@ -80,6 +81,16 @@ public class Project
     public ArrayList<String> getCommonTestingFiles()
     {
         return m_commontestingfiles;
+    }
+
+    public void addTypeObjectTestingFile(String file)
+    {
+        m_typeobjecttestingfiles.add(file);
+    }
+
+    public ArrayList<String> getTypeObjectTestingFiles()
+    {
+        return m_typeobjecttestingfiles;
     }
 
     /*!
@@ -135,6 +146,7 @@ public class Project
     private ArrayList<String> m_commonsrcfiles = null;
     private ArrayList<String> m_commonincludefiles = null;
     private ArrayList<String> m_commontestingfiles = null;
+    private ArrayList<String> m_typeobjecttestingfiles = null;
     private LinkedHashSet<String> m_dependencies = null;
     String m_guid = null;
     Solution m_parent = null;

--- a/src/main/java/com/eprosima/solution/Solution.java
+++ b/src/main/java/com/eprosima/solution/Solution.java
@@ -14,6 +14,7 @@
 
 package com.eprosima.solution;
 
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.log.ColorMessage;
 import java.util.ArrayList;
 
@@ -103,6 +104,19 @@ public class Solution
 		}
 
 	    return m_cacheprojects;
+	}
+
+	/*!
+	 * @brief Only valid if one IDL is passed to Fast DDS-Gen. Used only in testing environment.
+	 */
+	public Project getMainProject() throws RuntimeGenerationException
+	{
+		ArrayList projects = getProjects();
+		if (projects.isEmpty())
+		{
+			throw new RuntimeGenerationException("Error: no projects have been defined");
+		}
+		return (Project)projects.get(projects.size() - 1);
 	}
 
     public boolean existsProject(String name)


### PR DESCRIPTION
This PR includes changes required to generate the XTypes v1.3 IDL files and the code to register the associated TypeObjects defined in the specification. Specifically, this PR includes:

* New `-genapi` option that prepends to the OMG IDL module names the `eprosima::fastdds` namespace (developer option).
* Remove `-cdr` option because from this point onward only Fast CDR v2 is going to be supported.
* New `-default-container-prealloc-size` option to select how many elements to preallocate in the generated code for unbounded collections.
* New `-no-typeobject-support` option to disable the TypeObject code generation.
* Infrastructure to add tests for TypeObject generated code.
* Several refactors for typecodes:
    * Unions: discriminator and default value.
    * C++ enum class
    * New MemberAppliedAnnotations class to apply annotations to collection elements (partially supported. Collection element annotations are not yet parsed in the grammar and added to the element).
    * Correctly register builtin annotations defined in IDL v4.2 and XTypes v1.3 specifications. Add API to access and check builtin annotations.
    * Fix collections API to return correct TypeIdentifier discriminator depending on the bound size.
    * Extend primitive Typecode API to check primitive kind.
    * API to return collection's size.
* STGroup template configuration
* Improve documentation