### PR TITLE
Fix parsing IDL oneway operations [21145]

### DIFF
--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -2320,7 +2320,8 @@ op_decl [Vector<Annotation> annotations] returns [Pair<Operation, TemplateGroup>
         Vector<Pair<String, Token>> exceptions = null;
 }
     :   ( op_attribute { tkoneway=$op_attribute.token; } )?
-        op_type_spec { retType=$op_type_spec.returnPair.first(); template=$op_type_spec.returnPair.second();}
+        op_type_spec { if(null != $op_type_spec.returnPair) {retType=$op_type_spec.returnPair.first();
+            template=$op_type_spec.returnPair.second();}}
         {
             tk = _input.LT(1);
             name += tk.getText();

--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -113,12 +113,6 @@ public class Context
             m_file = m_file.substring(m_directoryFile.length());
          */
 
-        m_definitions = new ArrayList<Definition>();
-        m_modules = new HashMap<String, com.eprosima.idl.parser.tree.Module>();
-        m_interfaces = new HashMap<String, Interface>();
-        m_exceptions = new HashMap<String, com.eprosima.idl.parser.tree.Exception>();
-        m_types = new HashMap<String, TypeDeclaration>();
-        m_annotations = new HashMap<String, AnnotationDeclaration>();
         m_keywords = new HashSet<String>();
         fillKeywords();
 
@@ -793,6 +787,11 @@ public class Context
     {
         BitfieldSpec object = new BitfieldSpec(m_scope, size, type);
         return object;
+    }
+
+    public Collection<com.eprosima.idl.parser.tree.Exception> getExceptions()
+    {
+        return m_exceptions.values();
     }
 
     public Collection<TypeDeclaration> getTypes()
@@ -1538,17 +1537,17 @@ public class Context
     final String includeFlag = "-I";
 
     //! Store all global definitions.
-    private ArrayList<Definition> m_definitions;
+    private ArrayList<Definition> m_definitions = new ArrayList<Definition>();
     //! Map that contains all modules that were found processing the IDL file (after preprocessing):
-    private HashMap<String, com.eprosima.idl.parser.tree.Module> m_modules = null;
+    private HashMap<String, com.eprosima.idl.parser.tree.Module> m_modules = new HashMap<String, com.eprosima.idl.parser.tree.Module>();
     //! Map that contains all interfaces that were found processing the IDL file (after preprocessing):
-    private HashMap<String, Interface> m_interfaces = null;
+    private HashMap<String, Interface> m_interfaces = new HashMap<String, Interface>();
     //! Map that contains all global exceptions that were found processing the IDL file (after preprocessing).
-    private HashMap<String, com.eprosima.idl.parser.tree.Exception> m_exceptions = null;
+    private HashMap<String, com.eprosima.idl.parser.tree.Exception> m_exceptions = new HashMap<String, com.eprosima.idl.parser.tree.Exception>();
     //! Map that contains all types that were found processing the IDL file (after preprocessing).
-    protected HashMap<String, TypeDeclaration> m_types = null;
+    private HashMap<String, TypeDeclaration> m_types = new HashMap<String, TypeDeclaration>();
     //! Map that contains all annotations that where found processing the IDL file.
-    private HashMap<String, AnnotationDeclaration> m_annotations = null;
+    private HashMap<String, AnnotationDeclaration> m_annotations = new HashMap<String, AnnotationDeclaration>();
 
     private ArrayList<String> m_includePaths = null;
     //! Set that contains the library dependencies that were found because there was a line of the preprocessor.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Currently the parser fails if it encounters a oneway operation. This PR fixes it.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.7.x 1.6.x 1.3.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* Any new/modified methods have been properly documented.
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ Check CI results: changes do not issue any warning.
- _N/A_ Check CI results: failing tests are unrelated with the changes.
