### PR TITLE
Annotations for union's discriminators [21236]

### DIFF
--- a/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
+++ b/src/main/antlr/com/eprosima/idl/parser/grammar/IDL.g4
@@ -1694,6 +1694,7 @@ union_type [Vector<Annotation> annotations, ArrayList<Definition> defs] returns 
     UnionTypeCode unionTP = null;
     TemplateGroup unionTemplates = null;
     Boolean fw_decl = false;
+    ArrayList<Annotation> discriminator_annotations = new ArrayList<Annotation>();
 }
     :   KW_UNION
         identifier
@@ -1732,7 +1733,7 @@ union_type [Vector<Annotation> annotations, ArrayList<Definition> defs] returns 
                 }
             }
         }
-        KW_SWITCH LEFT_BRACKET switch_type_spec { dist_type=$switch_type_spec.typecode; } RIGHT_BRACKET
+        KW_SWITCH LEFT_BRACKET (annotation_appl { discriminator_annotations.add($annotation_appl.annotation); })? switch_type_spec { dist_type=$switch_type_spec.typecode; } RIGHT_BRACKET
         {
             // TODO Check supported types for discriminator: long, enumeration, etc...
             if (fw_decl)
@@ -1752,6 +1753,12 @@ union_type [Vector<Annotation> annotations, ArrayList<Definition> defs] returns 
                 unionTP = ctx.createUnionTypeCode(ctx.getScope(), name, dist_type);
             }
             unionTP.setDefined();
+
+            // Set discriminator annotations.
+            for(Annotation annotation : discriminator_annotations)
+            {
+                unionTP.getDiscriminator().addAnnotation(ctx, annotation);
+            }
 
             // Apply annotations to the TypeCode
             if (null != annotations)

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -68,7 +68,8 @@ public class TemplateUtil
                     disc_type.getKind() == Kind.KIND_CHAR ||
                     disc_type.getKind() == Kind.KIND_WCHAR)
             {
-                long dvalue = -1;
+                long default_discriminator_value = -1;
+                long minimum_valid_value = -1;
 
                 // For primitive types, if the default case was not defined, use the highest unused value as the
                 // implicit default value.
@@ -78,19 +79,23 @@ public class TemplateUtil
                     case Kind.KIND_INT8:
                     case Kind.KIND_UINT8:
                     case Kind.KIND_CHAR:
-                        dvalue = Byte.MAX_VALUE;
+                        default_discriminator_value = Byte.MAX_VALUE;
+                        minimum_valid_value = Byte.MIN_VALUE;
                         break;
                     case Kind.KIND_SHORT:
                     case Kind.KIND_USHORT:
                     case Kind.KIND_WCHAR:
-                        dvalue = Short.MAX_VALUE;
+                        default_discriminator_value = Short.MAX_VALUE;
+                        minimum_valid_value = Short.MIN_VALUE;
                         break;
                     case Kind.KIND_LONG:
                     case Kind.KIND_ULONG:
-                        dvalue = Integer.MAX_VALUE;
+                        default_discriminator_value = Integer.MAX_VALUE;
+                        minimum_valid_value = Integer.MIN_VALUE;
                         break;
                     default:
-                        dvalue = Long.MAX_VALUE;
+                        default_discriminator_value = Long.MAX_VALUE;
+                        minimum_valid_value = Long.MIN_VALUE;
                 }
 
                 boolean found = true;
@@ -132,7 +137,7 @@ public class TemplateUtil
                                     }
                                 }
 
-                                if(dvalue == value)
+                                if(default_discriminator_value == value)
                                 {
                                     found = true;
                                     break;
@@ -143,15 +148,21 @@ public class TemplateUtil
                         if(found)
                         {
                             // Possible default implicit value used. Try with the next lower value.
-                            --dvalue;
+                            --default_discriminator_value;
                             break;
                         }
                     }
                 }
-                while(found);
+                while(found && default_discriminator_value >= minimum_valid_value);
 
-                union_type.setDefaultvalue(Long.toString(dvalue));
-                union_type.setJavaDefaultvalue(Long.toString(dvalue));
+                if (found)
+                {
+                    // All values were used. Using value 0 as default implicit value.
+                    default_discriminator_value = 0;
+                }
+
+                union_type.setDefaultvalue(Long.toString(default_discriminator_value));
+                union_type.setJavaDefaultvalue(Long.toString(default_discriminator_value));
             }
             else if(disc_type.getKind() == Kind.KIND_BOOLEAN)
             {

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -70,6 +70,8 @@ public class TemplateUtil
             {
                 long dvalue = -1;
 
+                // For primitive types, if default case was not defined, we will find a not used value starting for
+                // the maximum value of the primitive type for the default implicit value.
                 switch (disc_type.getKind())
                 {
                     case Kind.KIND_OCTET:
@@ -140,6 +142,7 @@ public class TemplateUtil
 
                         if(found)
                         {
+                            // Possible default implicit value used. Changing to test the former value.
                             --dvalue;
                             break;
                         }

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -69,12 +69,33 @@ public class TemplateUtil
                     disc_type.getKind() == Kind.KIND_WCHAR)
             {
                 long dvalue = -1;
+
+                switch (disc_type.getKind())
+                {
+                    case Kind.KIND_OCTET:
+                    case Kind.KIND_INT8:
+                    case Kind.KIND_UINT8:
+                    case Kind.KIND_CHAR:
+                        dvalue = Byte.MAX_VALUE;
+                        break;
+                    case Kind.KIND_SHORT:
+                    case Kind.KIND_USHORT:
+                    case Kind.KIND_WCHAR:
+                        dvalue = Short.MAX_VALUE;
+                        break;
+                    case Kind.KIND_LONG:
+                    case Kind.KIND_ULONG:
+                        dvalue = Integer.MAX_VALUE;
+                        break;
+                    default:
+                        dvalue = Long.MAX_VALUE;
+                }
+
                 boolean found = true;
                 List<Member> list = new ArrayList<Member>(members);
 
                 do
                 {
-                    ++dvalue;
                     found = false;
 
                     for(Member member : list)
@@ -117,7 +138,11 @@ public class TemplateUtil
                             }
                         }
 
-                        if(found) break;
+                        if(found)
+                        {
+                            --dvalue;
+                            break;
+                        }
                     }
                 }
                 while(found);

--- a/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
+++ b/src/main/java/com/eprosima/idl/generator/manager/TemplateUtil.java
@@ -70,8 +70,8 @@ public class TemplateUtil
             {
                 long dvalue = -1;
 
-                // For primitive types, if default case was not defined, we will find a not used value starting for
-                // the maximum value of the primitive type for the default implicit value.
+                // For primitive types, if the default case was not defined, use the highest unused value as the
+                // implicit default value.
                 switch (disc_type.getKind())
                 {
                     case Kind.KIND_OCTET:
@@ -142,7 +142,7 @@ public class TemplateUtil
 
                         if(found)
                         {
-                            // Possible default implicit value used. Changing to test the former value.
+                            // Possible default implicit value used. Try with the next lower value.
                             --dvalue;
                             break;
                         }

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -123,8 +123,8 @@ public class UnionTypeCode extends MemberedTypeCode
             javalabels = internal_labels;
         }
 
-        // Checks the discriminator has the @default annotation. In that case checks the union's member has a label with
-        // the @default annotation value and if they matches store the union's member index.
+        // Checks the discriminator has the @default annotation. In that case check the union's member has a label with
+        // the @default annotation value and if they match store the union's member index.
         try
         {
             if (discriminator_.isAnnotationDefault())
@@ -141,6 +141,7 @@ public class UnionTypeCode extends MemberedTypeCode
                         }
                         else
                         {
+                            // Default value matches with more than one member.
                             return -2;
                         }
                     }
@@ -179,7 +180,7 @@ public class UnionTypeCode extends MemberedTypeCode
         }
         else if (discriminator_.isAnnotationDefault())
         {
-            throw new RuntimeGenerationException("UnionTypeCode::getDefaultAnnotatedMember(): Discriminator has a default value but that value not found in label cases");
+            throw new RuntimeGenerationException("UnionTypeCode::getDefaultAnnotatedMember(): Discriminator has a default value but that value was not found in label cases");
         }
 
         return null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -123,6 +123,8 @@ public class UnionTypeCode extends MemberedTypeCode
             javalabels = internal_labels;
         }
 
+        // Checks the discriminator has the @default annotation. In that case checks the union's member has a label with
+        // the @default annotation value and if they matches store the union's member index.
         try
         {
             if (discriminator_.isAnnotationDefault())
@@ -163,6 +165,12 @@ public class UnionTypeCode extends MemberedTypeCode
         return 0;
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function returns the union's member which contains a label that matches with discriminator's
+     * @default annotation. If no one then return \b null.
+     * @return The union's member that passes the conditions or \b null value.
+     */
     public Member getDefaultAnnotatedMember() throws RuntimeGenerationException
     {
         if (m_defaultannotated_index != -1)
@@ -261,6 +269,12 @@ public class UnionTypeCode extends MemberedTypeCode
         m_javaDefaultValue = value;
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function returns the discriminator's @default annotation value as string. If annotation was not
+     * defined, returns \b null.
+     * @return The discriminator's @default annotation value or \b null if annotation was not defined
+     */
     public String getDefaultAnnotatedValue()
     {
         try
@@ -339,6 +353,10 @@ public class UnionTypeCode extends MemberedTypeCode
 
     private int m_defaultindex = -1;
 
+    /*!
+     * Stores the index of the union's member which contains a label that matches with the discriminator's @default
+     * annotation.
+     */
     private int m_defaultannotated_index = -1;
 
     private String m_defaultValue = null;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds annotations for union's discriminator in the grammar. Also it adds the `@default` annotation for union's discriminator in the library. And it changes how to calculate the discriminator's value for default case in primitive types: instead of searching for the lower value, it searches the greater one.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.7.x 1.6.x 1.3.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Any new/modified methods have been properly documented.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
