### PR TITLE
[21313] Allow all @default annotation values for unions

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -178,10 +178,6 @@ public class UnionTypeCode extends MemberedTypeCode
         {
             return getMembers().get(m_defaultannotated_index);
         }
-        else if (discriminator_.isAnnotationDefault())
-        {
-            throw new RuntimeGenerationException("UnionTypeCode::getDefaultAnnotatedMember(): Discriminator has a default value but that value was not found in label cases");
-        }
 
         return null;
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -172,7 +172,7 @@ public class UnionTypeCode extends MemberedTypeCode
      * @default annotation. If no one then return \b null.
      * @return The union's member that passes the conditions or \b null value.
      */
-    public Member getDefaultAnnotatedMember() throws RuntimeGenerationException
+    public Member getDefaultAnnotatedMember()
     {
         if (m_defaultannotated_index != -1)
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR enables the use of any `@default` annotation value for unions.
Required by:

* eProsima/Fast-DDS#5081

Depends on:

*eProsima/dds-types-test#34

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.7.x 1.6.x 1.3.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: Any new/modified methods have been properly documented.
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
