### PR TITLE
[21391] Add new function getMembersById for STG

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -16,6 +16,8 @@ package com.eprosima.idl.parser.typecode;
 
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.function.Function;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -126,9 +128,37 @@ public abstract class MemberedTypeCode extends TypeCode
         return !m_scope.isEmpty();
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function can be used to return all members ordered by index (insertion).
+     * @return List of all members ordered by index.
+     */
     public List<Member> getMembers()
     {
         return new ArrayList<Member>(m_members.values());
+    }
+
+    private class ComparatorById implements Comparator<Member>
+    {
+        @Override
+        public int compare(
+            Member m1,
+            Member m2)
+        {
+            return m1.get_id() - m2.get_id();
+        }
+    }
+
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function can be used to return all members ordered by MemberId.
+     * @return List of all members ordered by MemberId.
+     */
+    public List<Member> getMembersById()
+    {
+        ArrayList<Member> ret_list = new ArrayList<Member>(m_members.values());
+        Collections.sort(ret_list, new ComparatorById());
+        return ret_list;
     }
 
     public int getMembersSize()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR implements a new function `getMemberById` for being used in STG.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.7.x 1.6.x 1.3.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Any new/modified methods have been properly documented.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_:  Check CI results: failing tests are unrelated with the changes.
