### PR TITLE
[21595] Unions with Boolean or Enumeration discriminator might not be initialized correctly

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -188,6 +188,12 @@ public class UnionTypeCode extends MemberedTypeCode
         {
             return getMembers().get(m_defaultindex);
         }
+        else if((Kind.KIND_BOOLEAN == discriminator_.getTypecode().getKind() && 2 == getMembers().size()) ||
+                (Kind.KIND_ENUM == discriminator_.getTypecode().getKind() &&
+                 ((EnumTypeCode)discriminator_.getTypecode()).getMembers().size() == getTotallabels().size()))
+        {
+            return getMembers().get(0);
+        }
 
         return null;
     }

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -184,15 +184,17 @@ public class UnionTypeCode extends MemberedTypeCode
 
     /*!
      * @ingroup api_for_stg
-     * @brief This function returns the union's default member (there is no implicit default).
-     * This member is selected as the default one according to one of this cases:
-     * - It is selected by the `default` case label.
-     * - All possible values of the discriminator's type are covered and the first member is selected as default.
+     * @brief This function returns the union's default member (when there is no implicit default).
+     * A member is selected as the default one according to one of these cases:
+     * - It is under the `default:` case label.
+     * - It is under the case label of the default discriminator.
+     * - All possible values of the discriminator's type are covered so the first member should be considered the default.
+     *
      * @return The union's default member.
      */
     public Member getDefaultMember()
     {
-        // Union's default member selected by `default` case label.
+        // Union's default member is explicitly selected (either under the `default:` case label or under the default discriminator value case label).
         if (m_defaultindex != -1)
         {
             return getMembers().get(m_defaultindex);

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -182,16 +182,27 @@ public class UnionTypeCode extends MemberedTypeCode
         return null;
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function returns the union's default member (there is no implicit default).
+     * This member is selected as the default one according to one of this cases:
+     * - It is selected by the `default` case label.
+     * - All possible values of the discriminator's type are covered and the first member is selected as default.
+     * @return The union's default member.
+     */
     public Member getDefaultMember()
     {
+        // Union's default member selected by `default` case label.
         if (m_defaultindex != -1)
         {
             return getMembers().get(m_defaultindex);
         }
+        // All possible values of a Boolean discriminator or Enumeration discriminator are covered.
         else if((Kind.KIND_BOOLEAN == discriminator_.getTypecode().getKind() && 2 == getTotallabels().size()) ||
                 (Kind.KIND_ENUM == discriminator_.getTypecode().getKind() &&
                  ((EnumTypeCode)discriminator_.getTypecode()).getMembers().size() == getTotallabels().size()))
         {
+            // First member is selected ad the default one.
             return getMembers().get(0);
         }
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/UnionTypeCode.java
@@ -188,7 +188,7 @@ public class UnionTypeCode extends MemberedTypeCode
         {
             return getMembers().get(m_defaultindex);
         }
-        else if((Kind.KIND_BOOLEAN == discriminator_.getTypecode().getKind() && 2 == getMembers().size()) ||
+        else if((Kind.KIND_BOOLEAN == discriminator_.getTypecode().getKind() && 2 == getTotallabels().size()) ||
                 (Kind.KIND_ENUM == discriminator_.getTypecode().getKind() &&
                  ((EnumTypeCode)discriminator_.getTypecode()).getMembers().size() == getTotallabels().size()))
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

For unions with boolean or enumeration discriminator if all cases are covered, the default discriminator value is set correctly to `true` or to first enumeration literal but the C++ constructor not initialize that member.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.5.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- *N/A* Any new/modified methods have been properly documented.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.

