### PR TITLE
Fix empty relative dir

### DIFF
--- a/src/main/java/com/eprosima/idl/context/Context.java
+++ b/src/main/java/com/eprosima/idl/context/Context.java
@@ -401,23 +401,24 @@ public class Context
         m_scope = scope;
     }
 
-    public String getRelativeDir(String dependant_idl_dir)
+    public String getRelativeDir()
     {
-        String relative_dir = Util.getIDLFileDirectoryOnly(m_file);
-
-        if(null != relative_dir)
+        String idl_dir = Util.getIDLFileDirectoryOnly(m_file);
+        String relative_dir = idl_dir;
+        int longest_size = 0;
+        if(null != idl_dir)
         {
-            File rel_dir = new File(relative_dir);
-
-            if (rel_dir.isAbsolute())
+            for (String includePath : m_includePaths)
             {
-                if (null != dependant_idl_dir && relative_dir.startsWith(dependant_idl_dir))
+                if (m_file.startsWith(includePath))
                 {
-                    relative_dir = relative_dir.substring(dependant_idl_dir.length());
-                }
-                else
-                {
-                    relative_dir = "";
+                    // To get the relative path find the longest common path
+                    // between any includePath and the IDL file directory.
+                    if (longest_size < includePath.length())
+                    {
+                        longest_size = includePath.length();
+                        relative_dir = idl_dir.substring(includePath.length());
+                    }
                 }
             }
         }
@@ -425,7 +426,6 @@ public class Context
         {
             relative_dir = "";
         }
-
         return relative_dir;
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
The Fast-DDS-Gen is not generating files in relative subdirectories in output directory even when there is no `-flat-output-dir` flag defined for fastddsgen.

With this change the relative path of the idl file is defined based on the largest common includePath (if there are multiple).
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.5.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ Any new/modified methods have been properly documented.
- ❌ Not checked yet.  Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible: The getRelativeDir() API changes as dependant_idl_dir is no more needed. The relative path is defined from the include path(s) and the idl file path. Brakes some test in Fast-DDS-Gen. <!-- Public API must not be broken within the same major release. -->
- ❌ Not checked yet.  Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
