### PR TITLE
Fix non flat output directory

### DIFF
--- a/src/main/java/com/eprosima/idl/test/TestIDLParser.java
+++ b/src/main/java/com/eprosima/idl/test/TestIDLParser.java
@@ -77,7 +77,7 @@ public class TestIDLParser {
         }
 
         TemplateManager tmanager = new TemplateManager();
-        Context context = new Context(tmanager, idlFileName, m_includePaths, false);
+        Context context = new Context(tmanager, idlFileName, m_includePaths, false, true);
 
         try {
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Currently, the generated files will be on most cases on flat output directory structure even if `-flat-output-dir` is not used or the relative path can't be controlled properly.

For example:
`fastddsgen -no-typeobjectsupport -replace -example CMake -typeros2 -cs -I ~/path/to/idl/ros2 -t ~/tmp -d ~/generated ~/path/to/idl/ros2/sensor_msgs/msg/PointCloud2.idl`

will generate the files as flat:
.
├── CMakeLists.txt
├── Header.hpp
├── HeaderApplication.cxx
├── HeaderApplication.hpp
├── HeaderCdrAux.hpp
├── HeaderCdrAux.ipp
├── HeaderPubSubTypes.cxx
├── HeaderPubSubTypes.hpp
├── HeaderPublisherApp.cxx
├── HeaderPublisherApp.hpp
├── HeaderSubscriberApp.cxx
├── HeaderSubscriberApp.hpp
├── Headermain.cxx
├── PointCloud2.hpp
├── PointCloud2Application.cxx
├── PointCloud2Application.hpp
├── PointCloud2CdrAux.hpp
├── PointCloud2CdrAux.ipp
├── PointCloud2PubSubTypes.cxx
├── PointCloud2PubSubTypes.hpp
├── PointCloud2PublisherApp.cxx
├── PointCloud2PublisherApp.hpp
├── PointCloud2SubscriberApp.cxx
├── PointCloud2SubscriberApp.hpp
├── PointCloud2main.cxx
├── PointField.hpp
├── PointFieldApplication.cxx
├── PointFieldApplication.hpp
├── PointFieldCdrAux.hpp
├── PointFieldCdrAux.ipp
├── PointFieldPubSubTypes.cxx
├── PointFieldPubSubTypes.hpp
├── PointFieldPublisherApp.cxx
├── PointFieldPublisherApp.hpp
├── PointFieldSubscriberApp.cxx
├── PointFieldSubscriberApp.hpp
├── PointFieldmain.cxx
├── Time.hpp
├── TimeApplication.cxx
├── TimeApplication.hpp
├── TimeCdrAux.hpp
├── TimeCdrAux.ipp
├── TimePubSubTypes.cxx
├── TimePubSubTypes.hpp
├── TimePublisherApp.cxx
├── TimePublisherApp.hpp
├── TimeSubscriberApp.cxx
├── TimeSubscriberApp.hpp
└── Timemain.cxx

With this change (and the change in Fast-DDS-Gen https://github.com/eProsima/Fast-DDS-Gen/pull/449) the output will be:
.
├── CMakeLists.txt
├── builtin_interfaces
│   └── msg
│       ├── Time.hpp
│       ├── TimeApplication.cxx
│       ├── TimeApplication.hpp
│       ├── TimeCdrAux.hpp
│       ├── TimeCdrAux.ipp
│       ├── TimePubSubTypes.cxx
│       ├── TimePubSubTypes.hpp
│       ├── TimePublisherApp.cxx
│       ├── TimePublisherApp.hpp
│       ├── TimeSubscriberApp.cxx
│       ├── TimeSubscriberApp.hpp
│       └── Timemain.cxx
├── sensor_msgs
│   └── msg
│       ├── PointCloud2.hpp
│       ├── PointCloud2Application.cxx
│       ├── PointCloud2Application.hpp
│       ├── PointCloud2CdrAux.hpp
│       ├── PointCloud2CdrAux.ipp
│       ├── PointCloud2PubSubTypes.cxx
│       ├── PointCloud2PubSubTypes.hpp
│       ├── PointCloud2PublisherApp.cxx
│       ├── PointCloud2PublisherApp.hpp
│       ├── PointCloud2SubscriberApp.cxx
│       ├── PointCloud2SubscriberApp.hpp
│       ├── PointCloud2main.cxx
│       ├── PointField.hpp
│       ├── PointFieldApplication.cxx
│       ├── PointFieldApplication.hpp
│       ├── PointFieldCdrAux.hpp
│       ├── PointFieldCdrAux.ipp
│       ├── PointFieldPubSubTypes.cxx
│       ├── PointFieldPubSubTypes.hpp
│       ├── PointFieldPublisherApp.cxx
│       ├── PointFieldPublisherApp.hpp
│       ├── PointFieldSubscriberApp.cxx
│       ├── PointFieldSubscriberApp.hpp
│       └── PointFieldmain.cxx
└── std_msgs
    └── msg
        ├── Header.hpp
        ├── HeaderApplication.cxx
        ├── HeaderApplication.hpp
        ├── HeaderCdrAux.hpp
        ├── HeaderCdrAux.ipp
        ├── HeaderPubSubTypes.cxx
        ├── HeaderPubSubTypes.hpp
        ├── HeaderPublisherApp.cxx
        ├── HeaderPublisherApp.hpp
        ├── HeaderSubscriberApp.cxx
        ├── HeaderSubscriberApp.hpp
        └── Headermain.cxx

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.5.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Any new/modified methods have been properly documented.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
