### PR TITLE
[23153] Improvements for `interface` and `@nested`

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/tree/Exception.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Exception.java
@@ -100,6 +100,12 @@ public class Exception extends TreeNode implements Export, Definition
         return true;
     }
 
+    @Override
+    protected boolean isDeclaredInsideInterface()
+    {
+        return m_parent instanceof Interface;
+    }
+
     private Object m_parent = null;
     private List<Member> m_members = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/tree/Operation.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Operation.java
@@ -198,6 +198,12 @@ public class Operation extends TreeNode implements Export
         return false;
     }
 
+    @Override
+    protected boolean isDeclaredInsideInterface()
+    {
+        return true;
+    }
+
     private Object m_parent = null;
     private boolean m_isOneway = false;
     private ArrayList<Param> m_params;

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -134,6 +134,13 @@ public class TreeNode implements Notebook
         return m_annotations;
     }
 
+    /**
+     * @brief This function checks if the node is annotated as nested.
+     *
+     * It is designed so it can be used in the templates with `$if(node.annotatedAsNested)$`
+     *
+     * @return true if the node is annotated as nested, false otherwise.
+     */
     public boolean isAnnotatedAsNested()
     {
         Annotation ann = m_annotations.get(Annotation.nested_str);

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -135,6 +135,7 @@ public class TreeNode implements Notebook
     }
 
     /**
+     * @ingroup api_for_stg
      * @brief This function checks if the node is annotated as nested.
      *
      * It is designed so it can be used in the templates with `$if(node.annotatedAsNested)$`

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -15,6 +15,7 @@
 package com.eprosima.idl.parser.tree;
 
 import com.eprosima.idl.context.Context;
+import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -131,6 +132,23 @@ public class TreeNode implements Notebook
     public Map<String, Annotation> getAnnotations()
     {
         return m_annotations;
+    }
+
+    public boolean isAnnotatedAsNested()
+    {
+        Annotation ann = m_annotations.get(Annotation.nested_str);
+        if (ann != null)
+        {
+            try
+            {
+                return ann.getValue().toUpperCase().equals(Annotation.capitalized_true_str);
+            }
+            catch (RuntimeGenerationException ex)
+            {
+                // Should not be called as @nested annotation has only one parameter
+            }
+        }
+        return false;
     }
 
     public Token getToken()

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -94,6 +94,35 @@ public class TreeNode implements Notebook
         return m_scope;
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function returns the namespace where the type would be declared.
+     * @return Namespace where the type would be declared.
+     */
+    public String getNamespace()
+    {
+        String namespace = m_scope;
+        // Remove last scope when declared inside an Interface
+        if (isDeclaredInsideInterface())
+        {
+            int last_index = m_scope.lastIndexOf("::");
+            if (last_index == -1)
+            {
+                namespace = "";
+            }
+            else
+            {
+                namespace = m_scope.substring(0, last_index);
+            }
+        }
+        return namespace;
+    }
+
+    protected boolean isDeclaredInsideInterface()
+    {
+        return false;
+    }
+
     /*
      * @brief This function returns the scoped name of the interface but
      * changing "::" by "_".

--- a/src/main/java/com/eprosima/idl/parser/tree/TypeDeclaration.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TypeDeclaration.java
@@ -108,6 +108,12 @@ public class TypeDeclaration extends TreeNode implements Definition, Export
         return super.isAnnotatedAsNested();
     }
 
+    @Override
+    protected boolean isDeclaredInsideInterface()
+    {
+        return m_parent instanceof Interface;
+    }
+
     private TypeCode m_typecode = null;
     private Object m_parent = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/tree/TypeDeclaration.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TypeDeclaration.java
@@ -97,6 +97,17 @@ public class TypeDeclaration extends TreeNode implements Definition, Export
         return true;
     }
 
+    @Override
+    public boolean isAnnotatedAsNested()
+    {
+        if (getParent() instanceof Interface)
+        {
+            return true;
+        }
+
+        return super.isAnnotatedAsNested();
+    }
+
     private TypeCode m_typecode = null;
     private Object m_parent = null;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -199,6 +199,12 @@ public class AliasTypeCode extends ContainerTypeCode
     }
 
     @Override
+    public String getNamespace()
+    {
+        return generate_namespace(m_scope);
+    }
+
+    @Override
     public String getCppTypename()
     {
         ST st = getCppTypenameFromStringTemplate();

--- a/src/main/java/com/eprosima/idl/parser/typecode/AnyTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AnyTypeCode.java
@@ -26,6 +26,12 @@ public class AnyTypeCode extends TypeCode
     }
 
     @Override
+    public String getNamespace()
+    {
+        return null;
+    }
+
+    @Override
     public String getCppTypename()
     {
         return null;

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
@@ -65,6 +65,11 @@ public class BitfieldSpec
         return !m_scope.isEmpty();
     }
 
+    public String getNamespace()
+    {
+        return "";
+    }
+
     public String getCppTypename()
     {
         return m_type.getCppTypename();

--- a/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/ContainerTypeCode.java
@@ -26,6 +26,12 @@ public abstract class ContainerTypeCode extends TypeCode
     }
 
     @Override
+    public String getNamespace()
+    {
+        return "";
+    }
+
+    @Override
     public abstract String getCppTypename();
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -129,6 +129,12 @@ public abstract class MemberedTypeCode extends TypeCode
         return !m_scope.isEmpty();
     }
 
+    @Override
+    public String getNamespace()
+    {
+        return generate_namespace(m_scope);
+    }
+
     /*!
      * @ingroup api_for_stg
      * @brief This function can be used to return all members ordered by index (insertion).

--- a/src/main/java/com/eprosima/idl/parser/typecode/PrimitiveTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/PrimitiveTypeCode.java
@@ -25,6 +25,12 @@ public class PrimitiveTypeCode extends TypeCode
     }
 
     @Override
+    public String getNamespace()
+    {
+        return "";
+    }
+
+    @Override
     public String getCppTypename()
     {
         return getCppTypenameFromStringTemplate().render();

--- a/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/StringTypeCode.java
@@ -105,6 +105,12 @@ public class StringTypeCode extends TypeCode
     }
 
     @Override
+    public String getNamespace()
+    {
+        return "";
+    }
+
+    @Override
     public String getCppTypename()
     {
         ST st = getCppTypenameFromStringTemplate();

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -76,6 +76,32 @@ public abstract class TypeCode implements Notebook
         return m_kind == Kind.KIND_NULL;
     }
 
+    /*!
+     * @ingroup api_for_stg
+     * @brief This function returns the namespace where the type would be declared.
+     * @return Namespace where the type would be declared.
+     */
+    public abstract String getNamespace();
+
+    protected String generate_namespace(String scope)
+    {
+        String namespace = scope;
+        // Remove last scope when declared inside an Interface
+        if (isDeclaredInsideInterface())
+        {
+            int last_index = scope.lastIndexOf("::");
+            if (last_index == -1)
+            {
+                namespace = "";
+            }
+            else
+            {
+                namespace = scope.substring(0, last_index);
+            }
+        }
+        return namespace;
+    }
+
     /*|
      * @brief This function returns the typename with the scope that is obtained using the cpptypesgr string template.
      * @return The IDL typename.

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -23,7 +23,9 @@ import org.stringtemplate.v4.STGroup;
 import com.eprosima.idl.context.Context;
 import com.eprosima.idl.parser.exception.RuntimeGenerationException;
 import com.eprosima.idl.parser.tree.Annotation;
+import com.eprosima.idl.parser.tree.Interface;
 import com.eprosima.idl.parser.tree.Notebook;
+import com.eprosima.idl.parser.tree.TypeDeclaration;
 
 
 public abstract class TypeCode implements Notebook
@@ -415,6 +417,25 @@ public abstract class TypeCode implements Notebook
             Object parent)
     {
         m_parent = parent;
+    }
+
+    /**
+     * @ingroup api_for_stg
+     * @brief This function returns true if the typecode is declared inside an interface.
+     * @return true if the typecode is declared inside an interface.
+     */
+    public boolean isDeclaredInsideInterface()
+    {
+        if (m_parent instanceof TypeDeclaration)
+        {
+            TypeDeclaration type_decl = (TypeDeclaration)m_parent;
+            if (type_decl.getParent() instanceof Interface)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

* Add `isAnnotatedAsNested` method to `TreeNode` so we can check for `@nested` annotation in the templates
* Add `getNamespace` method to `TreeNode` and `TypeCode` to help templates distinguish between `scope` and `namespace` for declarations inside interfaces
* Add `isDeclaredInsideInterface` method to `TypeCode` so we can check whether a type has been declared inside an interface in the templates.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.5.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - https://github.com/eProsima/dds-types-test/pull/43
- [x] Any new/modified methods have been properly documented.
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
