### PR TITLE
[23268] Methods for type object registration of types declared inside interfaces

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -125,10 +125,10 @@ public class TreeNode implements Notebook
      */
     public String getNameForTypeObjectRegistration()
     {
-        return interface_prefix() + getName();
+        return interfacePrefix() + getName();
     }
 
-    protected String interface_prefix()
+    protected String interfacePrefix()
     {
         // Get last scope when inside an interface
         if (isDeclaredInsideInterface())

--- a/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/TreeNode.java
@@ -118,6 +118,31 @@ public class TreeNode implements Notebook
         return namespace;
     }
 
+    /**
+     * @ingroup api_for_stg
+     * @brief This function returns the name to use in the type object registration methods.
+     * @return A string with the name to use in the type object registration methods.
+     */
+    public String getNameForTypeObjectRegistration()
+    {
+        return interface_prefix() + getName();
+    }
+
+    protected String interface_prefix()
+    {
+        // Get last scope when inside an interface
+        if (isDeclaredInsideInterface())
+        {
+            String[] scopes = m_scope.split("::");
+            if (scopes.length > 0)
+            {
+                return scopes[scopes.length - 1] + "__";
+            }
+        }
+
+        return "";
+    }
+
     protected boolean isDeclaredInsideInterface()
     {
         return false;

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -131,6 +131,16 @@ public class AliasTypeCode extends ContainerTypeCode
         return m_name;
     }
 
+    /**
+     * @ingroup api_for_stg
+     * @brief This function returns the name to use in the type object registration methods.
+     * @return A string with the name to use in the type object registration methods.
+     */
+    public String getNameForTypeObjectRegistration()
+    {
+        return interface_prefix() + getName();
+    }
+
     /*!
      * @brief Returns the full scoped name of the type, unless the developer uses
      * `TemplateSTGroup.enable_custom_proeprty("using_explicitly_modules")`, by removing from the full scoped name the

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -138,7 +138,7 @@ public class AliasTypeCode extends ContainerTypeCode
      */
     public String getNameForTypeObjectRegistration()
     {
-        return interface_prefix() + getName();
+        return interfacePrefix() + getName();
     }
 
     /*!

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -42,6 +42,16 @@ public abstract class MemberedTypeCode extends TypeCode
         return m_name;
     }
 
+    /**
+     * @ingroup api_for_stg
+     * @brief This function returns the name to use in the type object registration methods.
+     * @return A string with the name to use in the type object registration methods.
+     */
+    public String getNameForTypeObjectRegistration()
+    {
+        return interface_prefix() + getName();
+    }
+
     /*!
      * @brief Returns the full scoped name of the type, unless the developer uses
      * `TemplateSTGroup.enable_custom_proeprty("using_explicitly_modules")`, by removing from the full scoped name the

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -49,7 +49,7 @@ public abstract class MemberedTypeCode extends TypeCode
      */
     public String getNameForTypeObjectRegistration()
     {
-        return interface_prefix() + getName();
+        return interfacePrefix() + getName();
     }
 
     /*!

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -473,6 +473,35 @@ public abstract class TypeCode implements Notebook
         return false;
     }
 
+    protected String interface_prefix()
+    {
+        Interface interf = null;
+
+        if (m_parent instanceof TypeDeclaration)
+        {
+            TypeDeclaration type_decl = (TypeDeclaration)m_parent;
+            if (type_decl.getParent() instanceof Interface)
+            {
+                interf = (Interface)type_decl.getParent();
+            }
+        }
+        else if (m_parent instanceof Exception)
+        {
+            Exception ex = (Exception)m_parent;
+            if (ex.getParent() instanceof Interface)
+            {
+                interf = (Interface)ex.getParent();
+            }
+        }
+
+        if (interf == null)
+        {
+            return "";
+        }
+
+        return interf.getName() + "__";
+    }
+
     @Override
     public void addAnnotation(
             Context ctx,

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -473,7 +473,7 @@ public abstract class TypeCode implements Notebook
         return false;
     }
 
-    protected String interface_prefix()
+    protected String interfacePrefix()
     {
         Interface interf = null;
 

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -26,6 +26,7 @@ import com.eprosima.idl.parser.tree.Annotation;
 import com.eprosima.idl.parser.tree.Interface;
 import com.eprosima.idl.parser.tree.Notebook;
 import com.eprosima.idl.parser.tree.TypeDeclaration;
+import com.eprosima.idl.parser.tree.Exception;
 
 
 public abstract class TypeCode implements Notebook
@@ -456,6 +457,14 @@ public abstract class TypeCode implements Notebook
         {
             TypeDeclaration type_decl = (TypeDeclaration)m_parent;
             if (type_decl.getParent() instanceof Interface)
+            {
+                return true;
+            }
+        }
+        else if (m_parent instanceof Exception)
+        {
+            Exception ex = (Exception)m_parent;
+            if (ex.getParent() instanceof Interface)
             {
                 return true;
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds some methods to disambiguate the name of type object registration methods of types declared with the same name inside and outside an interface.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 1.5.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Any new/modified methods have been properly documented.
- **NO**: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
