### PR TITLE
Replace deprecated Jar.classifier with archiveClassifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ jar {
 }
 
 task sourceJar(type: Jar, dependsOn: classes) {
-   classifier = 'sources'
+   archiveClassifier = 'sources'
    from sourceSets.main.allJava
 }
 
@@ -91,7 +91,7 @@ publishing {
          from components.java
 
          artifact sourceJar {
-            classifier 'sources'
+            archiveClassifier = 'sources'
          }
       }
    }


### PR DESCRIPTION
## Problem

Building IDL-Parser with Gradle 7.0 or later fails during configuration:

```
A problem occurred evaluating project ':idl-parser'.
> Could not set unknown property 'classifier' for task ':idl-parser:sourceJar'
  of type org.gradle.api.tasks.bundling.Jar.
```

This blocks consumers of IDL-Parser (notably Fast-DDS-Gen) from upgrading their Gradle wrapper beyond 6.x, which in turn prevents building on systems running Java 11+ as the primary JDK.

### Root cause

The `classifier` property on `Jar` tasks was deprecated in Gradle 5.1 and **removed in Gradle 7.0**. Two usages remain in `build.gradle`:

```groovy
// line 74 — task declaration
task sourceJar(type: Jar, dependsOn: classes) {
    classifier = 'sources'   // ← removed in Gradle 7
    ...
}

// line 94 — artifact block inside publishing
artifact sourceJar {
    classifier 'sources'     // ← removed in Gradle 7
}
```

## Fix

Replace both with `archiveClassifier`, the supported API since Gradle 5.1:

```groovy
task sourceJar(type: Jar, dependsOn: classes) {
    archiveClassifier = 'sources'
    ...
}

artifact sourceJar {
    archiveClassifier = 'sources'
}
```

## Impact

- No behaviour change — the produced artifact still carries the `sources` classifier.
- Unblocks Gradle wrapper upgrades to 7.x / 8.x in dependent projects.
- Backwards compatible: `archiveClassifier` is available from Gradle 5.1 onward.

## Testing

Verified that IDL-Parser builds cleanly under Gradle 8.5 with Java 21 after this change, as part of a full Fast-DDS-Gen build on macOS arm64.