### PR TITLE
[24506] Add changes for custom buffer serialization

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -330,6 +330,12 @@ public class AliasTypeCode extends ContainerTypeCode
         return super.getContentTypeCode().isIsEnumType();
     }
 
+    @Override
+    public boolean isIsBufferType()
+    {
+        return super.getContentTypeCode().isIsBufferType();
+    }
+
     public boolean isIsType_10()
     {
         return true;

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -96,6 +96,7 @@ public class SequenceTypeCode extends ContainerTypeCode
     {
         ST st = getCppTypenameFromStringTemplate();
         st.add("ctx", ctx);
+        st.add("sequence_type_code", this);
         st.add("type", getContentTypeCode().getCppTypename());
         String contenttype = getContentTypeCode().getCppTypename().replaceAll("::", "_");
         if (getContentTypeCode() instanceof StringTypeCode)

--- a/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/SequenceTypeCode.java
@@ -81,6 +81,17 @@ public class SequenceTypeCode extends ContainerTypeCode
     }
 
     @Override
+    public boolean isIsBufferType()
+    {
+        if (isUnbound())
+        {
+            return getContentTypeCode().isIsByteType() || getContentTypeCode().isIsUint8Type();
+        }
+        
+        return false;
+    }
+
+    @Override
     public String getCppTypename()
     {
         ST st = getCppTypenameFromStringTemplate();

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -543,19 +543,19 @@ public abstract class TypeCode implements Notebook
             {
                 if (m_annotations.containsKey(Annotation.final_str) ||
                         (m_annotations.containsKey(Annotation.extensibility_str) &&
-                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_final_val)))
+                        m_annotations.get(Annotation.extensibility_str).getEnumStringValue().equals(Annotation.ex_final_str)))
                 {
                     extensibility_ = ExtensibilityKind.FINAL;
                 }
                 else if (m_annotations.containsKey(Annotation.appendable_str) ||
                         (m_annotations.containsKey(Annotation.extensibility_str) &&
-                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_appendable_val)))
+                        m_annotations.get(Annotation.extensibility_str).getEnumStringValue().equals(Annotation.ex_appendable_str)))
                 {
                     extensibility_ = ExtensibilityKind.APPENDABLE;
                 }
                 else if (m_annotations.containsKey(Annotation.mutable_str) ||
                         (m_annotations.containsKey(Annotation.extensibility_str) &&
-                        m_annotations.get(Annotation.extensibility_str).getValue().equals(Annotation.ex_mutable_val)))
+                        m_annotations.get(Annotation.extensibility_str).getEnumStringValue().equals(Annotation.ex_mutable_str)))
                 {
                     extensibility_ = ExtensibilityKind.MUTABLE;
                 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -396,6 +396,11 @@ public abstract class TypeCode implements Notebook
         return m_kind == Kind.KIND_UNION;
     }
 
+    public boolean isIsBufferType()
+    {
+        return false;
+    }
+
     // Functions to ease TypeIdentifier and TypeObject generation.
     public String getCppTypenameForTypeId()
     {

--- a/src/main/resources/com/eprosima/idl/templates/Types.stg
+++ b/src/main/resources/com/eprosima/idl/templates/Types.stg
@@ -58,8 +58,9 @@ type_c(name) ::= <<$name$>>
 
 type_10(name) ::= <<$name$>>
 
-// TODO Para que sirve empty en FastBuffers?
-type_e(ctx, type, contenttype, maxsize, empty) ::= <<std::vector<$type$>$empty$>>
+// Note: empty is never assigned. It is a helper to avoid '>>>' causing a syntax error when parsing the template,
+// and avoid an extra space when it is not needed.
+type_e(ctx, sequence_type_code, type, contenttype, maxsize, empty) ::= <<std::vector<$type$>$empty$>>
 
 type_1a(name, type) ::= <<$name$>>
 

--- a/src/main/resources/com/eprosima/idl/templates/TypesCInterface.stg
+++ b/src/main/resources/com/eprosima/idl/templates/TypesCInterface.stg
@@ -58,8 +58,9 @@ type_c(name) ::= <<$name$>>
 
 type_10(name) ::= <<$name$>>
 
-// TODO Para que sirve empty en FastBuffers?
-type_e(ctx, type, contenttype, maxsize, empty) ::= <<$ctx.filename$_$contenttype$Seq_$maxsize$_t>>
+// Note: empty is never assigned. It is a helper to avoid '>>>' causing a syntax error when parsing the template,
+// and avoid an extra space when it is not needed.
+type_e(ctx, sequence_type_code, type, contenttype, maxsize, empty) ::= <<$ctx.filename$_$contenttype$Seq_$maxsize$_t>>
 
 type_1a(name, type) ::= <<$name$>>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

* Added a new property that returns true for unbounded octet / uint8 sequences. It can be used from the templates as `typecode.isBufferType`.
* Pass the sequence's type code to the template that generates the cpp typename, so the new flag can be consulted.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.2.x 4.1.x 4.0.x 3.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: Any new/modified methods have been properly documented.
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
