### PR TITLE
[25500] Fix handling of null scope and `try_construct`

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
+++ b/src/main/java/com/eprosima/idl/parser/tree/Annotation.java
@@ -231,6 +231,16 @@ public class Annotation
         return ((AnnotationMember)m_members.values().toArray()[0]).getValue();
     }
 
+    public String getEnumStringValue() throws RuntimeGenerationException
+    {
+        if(m_members.size() != 1)
+        {
+            throw new RuntimeGenerationException("Error in annotation " + getName() +
+                    ": accessing value of a multiple parameter exception");
+        }
+        return ((AnnotationMember)m_members.values().toArray()[0]).getEnumStringValue();
+    }
+
     public String getValueFromAny(TypeCode typecode) throws RuntimeGenerationException
     {
         if(m_members.size() != 1)

--- a/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/AliasTypeCode.java
@@ -170,7 +170,7 @@ public class AliasTypeCode extends ContainerTypeCode
      */
     public String getFullScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -180,7 +180,7 @@ public class AliasTypeCode extends ContainerTypeCode
 
     public String getROS2Scopedname()
     {
-        if (m_scope.isEmpty())
+        if ((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -190,7 +190,7 @@ public class AliasTypeCode extends ContainerTypeCode
 
     public String getCScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -205,7 +205,7 @@ public class AliasTypeCode extends ContainerTypeCode
 
     public boolean getHasScope()
     {
-        return !m_scope.isEmpty();
+        return (m_scope != null) && !m_scope.isEmpty();
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/BitfieldSpec.java
@@ -62,7 +62,7 @@ public class BitfieldSpec
 
     public boolean getHasScope()
     {
-        return !m_scope.isEmpty();
+        return (m_scope != null) && !m_scope.isEmpty();
     }
 
     public String getNamespace()

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -232,21 +232,26 @@ public class MemberAppliedAnnotations implements Notebook
         {
             if (isAnnotationTryConstruct())
             {
-                if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_discard_str))
+                String annotation_value = m_annotations.get(Annotation.try_construct_str).getEnumStringValue();
+                if (annotation_value.equals(Annotation.try_construct_discard_str))
                 {
                     try_construct_ = TryConstructFailAction.DISCARD;
                 }
-                else if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_use_default_str))
+                else if (annotation_value.equals(Annotation.try_construct_use_default_str))
                 {
                     try_construct_ = TryConstructFailAction.USE_DEFAULT;
                 }
-                else if (m_annotations.get(Annotation.try_construct_str).getValue().equals(Annotation.try_construct_trim_str))
+                else if (annotation_value.equals(Annotation.try_construct_trim_str))
                 {
                     try_construct_ = TryConstructFailAction.TRIM;
                 }
+                else if (annotation_value.isEmpty())
+                {
+                    try_construct_ = TryConstructFailAction.USE_DEFAULT;
+                }
                 else
                 {
-                    throw new RuntimeGenerationException("try_construct annotation does not have a recognized value");
+                    throw new RuntimeGenerationException("try_construct annotation does not have a recognized value: '" + annotation_value + "'");
                 }
             }
             else

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberAppliedAnnotations.java
@@ -245,10 +245,6 @@ public class MemberAppliedAnnotations implements Notebook
                 {
                     try_construct_ = TryConstructFailAction.TRIM;
                 }
-                else if (annotation_value.isEmpty())
-                {
-                    try_construct_ = TryConstructFailAction.USE_DEFAULT;
-                }
                 else
                 {
                     throw new RuntimeGenerationException("try_construct annotation does not have a recognized value: '" + annotation_value + "'");

--- a/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/MemberedTypeCode.java
@@ -81,7 +81,7 @@ public abstract class MemberedTypeCode extends TypeCode
      */
     public String getFullScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -91,7 +91,7 @@ public abstract class MemberedTypeCode extends TypeCode
 
     public String getROS2Scopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -101,7 +101,7 @@ public abstract class MemberedTypeCode extends TypeCode
 
     public String getCScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -111,7 +111,7 @@ public abstract class MemberedTypeCode extends TypeCode
 
     public String getJavaScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -121,7 +121,7 @@ public abstract class MemberedTypeCode extends TypeCode
 
     public String getJniScopedname()
     {
-        if(m_scope.isEmpty())
+        if((m_scope == null) || m_scope.isEmpty())
         {
             return m_name;
         }
@@ -136,7 +136,7 @@ public abstract class MemberedTypeCode extends TypeCode
 
     public boolean getHasScope()
     {
-        return !m_scope.isEmpty();
+        return (m_scope != null) && !m_scope.isEmpty();
     }
 
     @Override

--- a/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/TypeCode.java
@@ -86,6 +86,11 @@ public abstract class TypeCode implements Notebook
 
     protected String generate_namespace(String scope)
     {
+        if (scope == null || scope.isEmpty())
+        {
+            return "";
+        }
+
         String namespace = scope;
         // Remove last scope when declared inside an Interface
         if (isDeclaredInsideInterface())


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 4.0.x 3.0.x 1.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] Any new/modified methods have been properly documented.
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
