### PR TITLE
[25558] Fix for enum literals implicit value

### DIFF
--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumMember.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumMember.java
@@ -20,4 +20,16 @@ public class EnumMember extends Member
     {
         super(null, name);
     }
+
+    public void setValue(int value)
+    {
+        value_ = value;
+    }
+
+    public int getValue()
+    {
+        return value_;
+    }
+
+    private int value_ = 0;
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
@@ -14,6 +14,9 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.eprosima.idl.parser.exception.ParseException;
 import com.eprosima.idl.parser.tree.Annotation;
 
@@ -74,6 +77,12 @@ public class EnumTypeCode extends MemberedTypeCode
                         Annotation.value_str + " value '" + member.getAnnotationValueValue() +
                         "' is not an integer.");
             }
+        }
+
+        if (!used_values_.add(next_value_))
+        {
+            throw new ParseException(null, "Error in member " + member.getName() +
+                    ": value " + next_value_ + " is already used by another literal.");
         }
 
         member.setValue(next_value_);
@@ -166,5 +175,7 @@ public class EnumTypeCode extends MemberedTypeCode
     }
 
     private int next_value_ = 0;
+
+    private Set<Integer> used_values_ = new HashSet<Integer>();
 
 }

--- a/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
+++ b/src/main/java/com/eprosima/idl/parser/typecode/EnumTypeCode.java
@@ -14,6 +14,9 @@
 
 package com.eprosima.idl.parser.typecode;
 
+import com.eprosima.idl.parser.exception.ParseException;
+import com.eprosima.idl.parser.tree.Annotation;
+
 import org.stringtemplate.v4.ST;
 
 
@@ -59,6 +62,23 @@ public class EnumTypeCode extends MemberedTypeCode
     public void addMember(
             EnumMember member)
     {
+        if (member.isAnnotationValue())
+        {
+            try
+            {
+                next_value_ = Integer.decode(member.getAnnotationValueValue().trim());
+            }
+            catch (NumberFormatException ex)
+            {
+                throw new ParseException(null, "Error in member " + member.getName() + ": @" +
+                        Annotation.value_str + " value '" + member.getAnnotationValueValue() +
+                        "' is not an integer.");
+            }
+        }
+
+        member.setValue(next_value_);
+        next_value_ = member.getValue() + 1;
+
         addMember((Member)member);
     }
 
@@ -144,5 +164,7 @@ public class EnumTypeCode extends MemberedTypeCode
         // TODO: pending @bit_bound annotation application to enum types
         return 32;
     }
+
+    private int next_value_ = 0;
 
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Enum literals without `@value` had no computed value in the model: only
`getIndex()` (declaration order) was available. That is only equal to the
literal's value when no `@value` appears earlier in the enumeration.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 4.3.x 4.0.x 3.0.x 1.2.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] Any new/modified methods have been properly documented.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
